### PR TITLE
build(deps): pin langchain family to 0.3.x/0.1.x lines to fix broken installs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,13 @@ dependencies = [
     "openai>=1.0.0",
     "pyyaml==6.0.1",
     "SQLAlchemy==2.0.22",
-    "langchain>=0.3.26",
-    "langchain-openai>=0.3.24",
-    "langchain-community>=0.3.26",
+    "langchain>=0.3.26,<0.4.0",
+    "langchain-openai>=0.3.24,<0.4.0",
+    "langchain-community>=0.3.26,<0.4.0",
     "tiktoken>=0.7.0",
     "python-dotenv~=1.0.0",
     "pyopenssl==23.3.0",
-    "langchain-mcp-adapters>=0.1.0",
+    "langchain-mcp-adapters>=0.1.0,<0.2.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Why this PR exists

`pyproject.toml` currently has no upper bound on the `langchain` family. A fresh `pip install connectchain` / `uv sync` today resolves **langchain 1.x**, which removed `langchain.chains`, `langchain.schema`, and `langchain.llms` — modules this codebase imports throughout. Result: every import of `connectchain` fails (`ModuleNotFoundError`) and the test suite is uncollectable on a clean environment.

## What it does

Adds upper bounds pinning to the lines the code actually targets — a 4-line diff, nothing else:

```
langchain>=0.3.26,<0.4.0
langchain-openai>=0.3.24,<0.4.0
langchain-community>=0.3.26,<0.4.0
langchain-mcp-adapters>=0.1.0,<0.2.0
```

## Verification

- `uv sync --dev` resolves langchain==0.3.30 (0.3.x line) and `python -c "import connectchain"` succeeds on a clean env.
- Full unit suite: 57 passed / 1 failed — the single failure (`test_model_with_unsupported_provider`) is **pre-existing on `main`** and unrelated to dependency resolution (it asserts an outdated error message; a separate PR addresses it).

## Sequencing

This is the first of a small series of focused PRs (dependency pin → sanitizer/orchestrator fixes → model/session/config fixes → MCP fixes → docs). The later PRs each include this pin so they build standalone; those hunks rebase away once this merges.

Co-authored-by: Claude <noreply@anthropic.com>
