### PR TITLE
fix: model init, session cache, retry semantics; config accessors raise AttributeError for missing keys

### DIFF
--- a/connectchain/lcel/model.py
+++ b/connectchain/lcel/model.py
@@ -10,19 +10,43 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 """LCEL model module"""
+import logging
 import os
-from typing import Any
+from typing import Any, Optional
+from urllib.parse import urlparse
 
 from langchain.schema.language_model import BaseLanguageModel
 from langchain_openai import AzureOpenAI, ChatOpenAI
 from pydantic import SecretStr
 
 from connectchain.utils import Config, SessionMap, get_token_from_env
+from connectchain.utils.exceptions import NonRetryableError
 from connectchain.utils.llm_proxy_wrapper import wrap_llm_with_proxy
 
+logger = logging.getLogger(__name__)
 
-class LCELModelException(BaseException):
-    """Base exception for the LCEL model"""
+_SUPPORTED_PROVIDERS = ("openai", "anthropic", "google", "cohere", "huggingface")
+
+
+class LCELModelException(Exception):
+    """Base exception for the LCEL model.
+
+    Deliberately NOT marked NonRetryableError: this base class also wraps
+    UNEXPECTED model-initialisation failures (see _get_direct_model_'s broad
+    except) whose retryability is unknown -- e.g. a transient network or
+    provider outage surfacing inside init_chat_model() -- so retry wrappers
+    (connectchain.utils.retry) must stay free to retry it. Known-permanent
+    configuration problems raise LCELModelConfigError instead; `except
+    LCELModelException` still catches both via the subclass relationship.
+    """
+
+
+class LCELModelConfigError(LCELModelException, NonRetryableError):
+    """A permanent configuration problem with the LCEL model: missing config
+    entry, unset API-key env var, unsupported provider, missing api_version,
+    or an uninstalled provider package. These will never succeed on retry, so
+    the NonRetryableError marker tells connectchain.utils.retry's wrappers to
+    re-raise immediately instead of burning retry attempts on nothing."""
 
 
 def model(index: Any = "1") -> BaseLanguageModel:
@@ -39,146 +63,204 @@ def _get_model_(index: Any) -> BaseLanguageModel:
     config = Config.from_env()
     try:
         models = config.models
-    except KeyError as ex:
-        raise LCELModelException("No models defined in config") from ex
+    except AttributeError as ex:
+        # Config raises AttributeError for a missing top-level key.
+        raise LCELModelConfigError("No models defined in config") from ex
     model_config = models[index]
     if model_config is None:
-        raise LCELModelException(f'Model config at index "{index}" is not defined')
+        raise LCELModelConfigError(f'Model config at index "{index}" is not defined')
 
-    # Check if we should use direct access (no EAS)
-    needs_eas = False
-    try:
-        # Check if EAS is configured and not bypassed
-        if (
-            hasattr(config, "eas")
-            and config.eas
-            and hasattr(config.eas, "id_key")
-            and config.eas.id_key
-            and not getattr(model_config, "bypass_eas", False)
-        ):
-            needs_eas = True
-    except (AttributeError, KeyError):
-        needs_eas = False
+    # EAS routing requires an eas section carrying a truthy id_key, unless the
+    # model opts out via bypass_eas. getattr's default genuinely works now that
+    # Config/ConfigWrapper raise AttributeError for missing keys -- and also
+    # for a section left empty in YAML (`eas:` parses to None, and attribute
+    # access on a None-holding wrapper raises AttributeError too) -- so the
+    # try/except probe cascade this replaces is no longer needed.
+    eas_config = getattr(config, "eas", None)
+    needs_eas = bool(getattr(eas_config, "id_key", None)) and not getattr(
+        model_config, "bypass_eas", False
+    )
 
-    # For non-OpenAI providers, always use direct access
     if model_config.provider != "openai":
         needs_eas = False
 
     if needs_eas:
-        # Use existing EAS flow for OpenAI
         model_instance = _get_openai_model_(index, config, model_config)
     else:
-        # Use direct access for any provider
         model_instance = _get_direct_model_(model_config)
 
     if model_instance is None:
-        raise LCELModelException("Not implemented")
-    try:
-        proxy_config = model_config.proxy
-    except KeyError:
-        # Proxy settings not required
-        pass
+        raise LCELModelConfigError("Not implemented")
+    # A model-level proxy overrides the global one; both are optional, so both
+    # reads use getattr's None default (missing keys raise AttributeError now).
+    proxy_config = getattr(model_config, "proxy", None)
     if proxy_config is None:
-        try:
-            proxy_config = config.proxy
-            # Proxy settings not required
-        except KeyError:
-            pass
+        proxy_config = getattr(config, "proxy", None)
     if proxy_config is not None:
-        # Convert to BaseLLM if needed for proxy wrapping
-        wrap_llm_with_proxy(model_instance, proxy_config)  # type: ignore[arg-type]
+        wrap_llm_with_proxy(model_instance, proxy_config)
     return model_instance
 
 
 def _get_openai_model_(index: Any, config: Any, model_config: Any) -> BaseLanguageModel:
     """Get the OpenAI LLM instance"""
     model_session_key = SessionMap.uuid_from_config(config, model_config)
-    auth_token = os.getenv(model_session_key)
-    session_map = SessionMap(config.eas.token_refresh_interval)
-    if auth_token is None or session_map.is_expired(model_session_key):
-        auth_token = get_token_from_env(index)
-        os.environ[model_session_key] = auth_token
-        if model_config.type == "chat":
-            llm: BaseLanguageModel = _get_chat_model_(auth_token, model_config)
-        else:
-            llm = _get_azure_model_(auth_token, model_config)
-        # Note: SessionMap expects LLMResult but we're storing LLM instances
-        session_map.new_session(model_session_key, llm)  # type: ignore[arg-type]
-        return llm
-    # Note: SessionMap returns LLMResult but we need BaseLanguageModel
-    return session_map.get_llm(model_session_key)  # type: ignore[return-value]
+    # Captured AND fully resolved now, before any I/O below, then passed explicitly
+    # to new_session() -- reading session_map.expires_in again after
+    # get_token_from_env()'s network call would race a concurrent request that
+    # reconstructs the singleton for a different model's token_refresh_interval in
+    # between. Resolving an unset token_refresh_interval (None) to the default HERE
+    # matters for the same reason: passing None would make new_session() fall back
+    # to the singleton's CURRENT expires_in after the network call, reopening the
+    # race and inheriting whatever interval another model configured last.
+    # token_refresh_interval is optional, hence getattr's None default.
+    expires_in = getattr(config.eas, "token_refresh_interval", None)
+    if expires_in is None:
+        expires_in = SessionMap.DEFAULT_EXPIRES_IN
+    session_map = SessionMap(expires_in)
+    if os.getenv(model_session_key) is not None:
+        # get_valid_llm() combines the expiry check and cache read into a single
+        # locked operation instead of two (is_expired() then get_llm()).
+        cached_llm = session_map.get_valid_llm(model_session_key)
+        if cached_llm is not None:
+            # Note: SessionMap is typed for LLMResult but we store LLM instances
+            return cached_llm  # type: ignore[return-value]
+    auth_token = get_token_from_env(index)
+    os.environ[model_session_key] = auth_token
+    if model_config.type == "chat":
+        llm: BaseLanguageModel = _get_chat_model_(auth_token, model_config)
+    else:
+        llm = _get_azure_model_(auth_token, model_config)
+    session_map.new_session(model_session_key, llm, expires_in)  # type: ignore[arg-type]
+    return llm
+
+
+# Azure OpenAI endpoint domains: public cloud, US Government, and China sovereign
+# clouds. APIM/custom domains can't be detected by hostname -- configs using one
+# should set `azure: true` on the model entry instead.
+_AZURE_ENDPOINT_MARKERS = ("openai.azure.com", "openai.azure.us", "openai.azure.cn")
+
+
+def _is_azure_endpoint_(model_config: Any, api_base: Any) -> bool:
+    """Whether this config targets Azure OpenAI: either an api_base whose HOSTNAME is
+    on a known Azure domain, or an explicit `azure: true` flag for custom/APIM domains.
+
+    The hostname is extracted with urlparse and suffix-matched (exact host or a
+    subdomain, i.e. host == marker or host.endswith("." + marker)) rather than
+    substring-matched over the whole URL: a substring match would misroute lookalikes
+    such as https://myproxy.corp.com/openai.azure.com-compat (marker in the path) or
+    https://notopenai.azure.com.evil.example (marker embedded in a non-Azure host)
+    to the Azure builder.
+    """
+    if getattr(model_config, "azure", None):
+        return True
+    if not api_base:
+        return False
+    parsed = urlparse(str(api_base))
+    hostname = parsed.hostname
+    if hostname is None:
+        # urlparse quirk: a scheme-less value like "my-resource.openai.azure.com/x"
+        # parses entirely into .path with no hostname. Re-parse as network-relative
+        # ("//host/...") so a scheme-less Azure api_base is still recognised as
+        # Azure instead of silently falling through to a plain OpenAI client.
+        hostname = urlparse(f"//{api_base}").hostname
+    if not hostname:
+        return False
+    # urlparse lowercases .hostname, so the comparison is already case-insensitive.
+    return any(
+        hostname == marker or hostname.endswith(f".{marker}")
+        for marker in _AZURE_ENDPOINT_MARKERS
+    )
+
+
+def _require_api_version_(model_config: Any, api_base: Any) -> Any:
+    """Validate api_version is configured before building an Azure client.
+
+    Without this, AzureOpenAI/ChatOpenAI(model_kwargs={"api_version": None, ...}) fails
+    with an opaque pydantic ValidationError ("Must provide either the api_version
+    argument or the OPENAI_API_VERSION environment variable") deep inside a third-party
+    constructor. Raising here gives a clear, actionable error instead.
+    """
+    api_version = getattr(model_config, "api_version", None)
+    if not api_version:
+        raise LCELModelConfigError(
+            f"Azure OpenAI endpoint detected ({api_base}) but no api_version is "
+            f"configured; api_version is required for Azure OpenAI."
+        )
+    # YAML parses an unquoted `api_version: 2024-02-01` as datetime.date, which the
+    # AzureOpenAI/ChatOpenAI pydantic validators reject with an opaque error. Coerce
+    # so both the quoted and the natural unquoted config spelling work.
+    return str(api_version)
+
+
+def _temperature_kwargs_(model_config: Any) -> dict:
+    """{'temperature': t} when configured, else {} -- so an unset temperature keeps
+    each provider's own default instead of being forced to None. getattr's None
+    default covers a missing key (ConfigWrapper raises AttributeError for those)
+    as well as an explicit `temperature: null`, and works the same for plain
+    (non-ConfigWrapper) config objects."""
+    temperature = getattr(model_config, "temperature", None)
+    return {} if temperature is None else {"temperature": temperature}
+
+
+def _azure_model_kwargs_(engine: Any) -> dict:
+    """Shared model_kwargs for AzureOpenAI. api_version is deliberately not repeated
+    here: both callers already pass it as a direct constructor kwarg, and AzureOpenAI's
+    pydantic validation rejects api_version appearing a second time inside model_kwargs
+    ('supplied twice')."""
+    return {"engine": engine, "api_type": "azure"}
 
 
 def _get_chat_model_(auth_token: str, model_config: Any) -> ChatOpenAI:
     """Get a ChatOpenAI instance"""
-    llm = ChatOpenAI(
-        # Note: ChatOpenAI uses model parameter
+    api_version = _require_api_version_(model_config, model_config.api_base)
+    return ChatOpenAI(
         model=model_config.model_name,
         api_key=SecretStr(auth_token) if auth_token else None,
         base_url=model_config.api_base,
-        model_kwargs={
-            "engine": model_config.engine,
-            "api_version": model_config.api_version,
-            "api_type": "azure",
-        },
+        # api_version goes inside model_kwargs here (unlike _get_azure_model_ /
+        # _get_direct_azure_model_) because ChatOpenAI has no top-level api_version kwarg.
+        model_kwargs={**_azure_model_kwargs_(model_config.engine), "api_version": api_version},
+        **_temperature_kwargs_(model_config),
     )
-    return llm
 
 
 def _get_azure_model_(auth_token: str, model_config: Any) -> AzureOpenAI:
     """Get an AzureOpenAI instance"""
-    llm = AzureOpenAI(
-        # Note: AzureOpenAI uses model parameter
+    api_version = _require_api_version_(model_config, model_config.api_base)
+    return AzureOpenAI(
         model=model_config.model_name,
         api_key=SecretStr(auth_token) if auth_token else None,
         azure_endpoint=model_config.api_base,
-        api_version=model_config.api_version,
-        model_kwargs={
-            "engine": model_config.engine,
-            "api_version": model_config.api_version,
-            "api_type": "azure",
-        },
+        api_version=api_version,
+        model_kwargs=_azure_model_kwargs_(model_config.engine),
+        **_temperature_kwargs_(model_config),
     )
-    return llm
 
 
-def _get_direct_model_(model_config: Any) -> BaseLanguageModel:
-    """Get a direct API model instance for any provider without EAS authentication"""
+def _get_direct_azure_model_(model_config: Any, api_key: str, api_base: Any) -> AzureOpenAI:
+    """Build a direct-API-key AzureOpenAI client.
 
-    try:
-        # Try using LangChain's automatic model initialization
-        from langchain.chat_models import init_chat_model
+    Called from _get_direct_model_ BEFORE the generic init_chat_model() fast path is
+    even attempted: that fast path has no notion of azure_endpoint/api_version/engine,
+    so routing an Azure-shaped api_base through it would silently succeed with a plain
+    ChatOpenAI pointed at the Azure URL instead of a working (or clearly failing) Azure
+    client.
+    """
+    api_version = _require_api_version_(model_config, api_base)
+    engine = getattr(model_config, "engine", None) or model_config.model_name
+    return AzureOpenAI(
+        model=model_config.model_name,
+        api_key=SecretStr(api_key),
+        azure_endpoint=api_base,
+        api_version=api_version,
+        model_kwargs=_azure_model_kwargs_(engine),
+        **_temperature_kwargs_(model_config),
+    )
 
-        # Prepare model name
-        model_name = model_config.model_name
 
-        # Prepare configuration kwargs
-        config_dict = {}
-
-        # Add custom API base if specified
-        if hasattr(model_config, "api_base") and model_config.api_base:
-            config_dict["base_url"] = model_config.api_base
-
-        # Add temperature if specified
-        if hasattr(model_config, "temperature"):
-            config_dict["temperature"] = model_config.temperature
-
-        # Handle custom API key environment variable
-        api_key_env = getattr(model_config, "api_key_env", None)
-        if api_key_env:
-            api_key = os.getenv(api_key_env)
-            if api_key:
-                config_dict["api_key"] = api_key
-
-        # Try automatic initialization
-        return init_chat_model(model_name, **config_dict)
-
-    except (ImportError, ValueError, Exception) as e:
-        # Fallback to manual provider-specific initialization
-        pass
-
-    # Manual provider-specific initialization as fallback
-    # Determine API key environment variable
+def _resolve_direct_api_key_(model_config: Any) -> str:
+    """Resolve the API key for a direct (non-EAS) model from its configured or
+    provider-default environment variable, raising a clear error if unset."""
     api_key_env = getattr(model_config, "api_key_env", None)
     if not api_key_env:
         # Default to {PROVIDER}_API_KEY pattern
@@ -186,94 +268,202 @@ def _get_direct_model_(model_config: Any) -> BaseLanguageModel:
 
     api_key = os.getenv(api_key_env)
     if not api_key:
-        raise LCELModelException(
+        raise LCELModelConfigError(
             f"API key not found in environment variable: {api_key_env}. "
             f"Please set it in your .env file or environment."
         )
+    return api_key
 
-    # Provider-specific instantiation
+
+def _resolve_fast_path_api_key_(model_config: Any) -> Optional[str]:
+    """Resolve an explicitly configured api_key_env for the init_chat_model()
+    fast path, returning None whenever resolution should instead be left to
+    init_chat_model()'s own provider-default handling.
+
+    Companion to _resolve_direct_api_key_ (the manual-fallback resolver); the
+    two deliberately differ on an UNSET named env var. Here we must not fail
+    hard: init_chat_model() resolves the provider's own default env var (e.g.
+    OPENAI_API_KEY) when no explicit api_key is passed, which may well work.
+    The misconfiguration is surfaced loudly via logger.warning, then init
+    proceeds without an explicit key. (The manual fallback path still
+    hard-fails via _resolve_direct_api_key_ if no key is resolvable at all.)
+    """
+    api_key_env = getattr(model_config, "api_key_env", None)
+    if not api_key_env:
+        return None
+    api_key = os.getenv(api_key_env)
+    if api_key:
+        return api_key
+    logger.warning(
+        "api_key_env is set to '%s' but that environment variable is unset; "
+        "falling back to the provider's default API-key environment variable "
+        "resolution.",
+        api_key_env,
+    )
+    return None
+
+
+def _get_direct_model_(model_config: Any) -> BaseLanguageModel:
+    """Get a direct API model instance for any provider without EAS authentication.
+
+    ImportError and ValueError from init_chat_model() are expected fallback
+    conditions (missing provider package, bad model name, or init_chat_model
+    itself unavailable on an old langchain): for providers with a manual
+    initialisation branch below (_SUPPORTED_PROVIDERS) they are logged as a
+    warning and fall through to that manual init; for any other provider there
+    is nothing to fall back to, so a clear LCELModelConfigError is raised
+    instead of the misleading fallback warning. Any other exception is
+    unexpected and is re-raised as (retry-eligible) LCELModelException with
+    the original traceback preserved via `raise ... from e`.
+    """
+    # Azure-shaped configs are routed straight to a dedicated Azure builder, BEFORE the
+    # generic init_chat_model() fast path below is ever attempted. init_chat_model() has
+    # no notion of azure_endpoint/api_version/engine, so letting an Azure api_base reach
+    # it would silently succeed with a plain, non-Azure ChatOpenAI instead of a working
+    # (or clearly failing) Azure client.
+    api_base = getattr(model_config, "api_base", None)
+    if model_config.provider == "openai" and _is_azure_endpoint_(model_config, api_base):
+        azure_api_key = _resolve_direct_api_key_(model_config)
+        return _get_direct_azure_model_(model_config, azure_api_key, api_base)
+
+    # Resolved before the try block so the env lookup can't be mistaken for an
+    # "unexpected" init error by the `except Exception` below.
+    explicit_api_key = _resolve_fast_path_api_key_(model_config)
+
+    try:
+        from langchain.chat_models import init_chat_model  # pylint: disable=import-outside-toplevel
+
+        model_name = model_config.model_name
+        config_dict: dict = {}
+
+        if api_base:
+            config_dict["base_url"] = api_base
+        config_dict.update(_temperature_kwargs_(model_config))
+        if explicit_api_key:
+            config_dict["api_key"] = explicit_api_key
+        if model_config.provider not in _SUPPORTED_PROVIDERS:
+            # Providers without a manual fallback branch below (mistralai, groq,
+            # ollama, bedrock, ...) are still served by init_chat_model(). For
+            # these, the configured provider is passed explicitly rather than
+            # inferred from model_name, so a genuinely unknown provider fails
+            # right here with init_chat_model()'s clear "Unsupported
+            # model_provider=..." ValueError instead of silently constructing a
+            # model for whatever provider the name happens to infer to (e.g.
+            # provider 'meta' with model_name 'gpt-4' must not build a ChatOpenAI).
+            config_dict["model_provider"] = model_config.provider
+
+        return init_chat_model(model_name, **config_dict)
+
+    except (ImportError, ValueError) as e:
+        # Expected: missing provider package, unrecognised model/provider name, or
+        # init_chat_model itself unavailable.
+        if model_config.provider not in _SUPPORTED_PROVIDERS:
+            # No manual initialisation branch exists for this provider, so the
+            # "falling back" warning below would be misleading -- there is nothing
+            # to fall back to. Fail fast with a clear error instead; the chained
+            # original (`from e`) explains WHY the fast path refused it (unknown
+            # provider vs. an uninstalled provider package).
+            raise LCELModelConfigError(
+                f"Provider '{model_config.provider}' not supported "
+                f"({type(e).__name__}: {e}). Providers with a built-in fallback: "
+                f"{', '.join(_SUPPORTED_PROVIDERS)}"
+            ) from e
+        # Log and fall through to the manual initialisation block below.
+        logger.warning(
+            "init_chat_model() failed for '%s' (%s: %s); falling back to manual provider init.",
+            model_config.model_name,
+            type(e).__name__,
+            e,
+        )
+    except Exception as e:  # pylint: disable=broad-except
+        # Unexpected failure: preserve the original traceback. Wrapped as the plain
+        # (retry-eligible) LCELModelException, NOT LCELModelConfigError: the cause
+        # here is by definition unknown -- it may be a transient network/provider
+        # error -- so it must not be branded never-retryable. Use getattr for the
+        # model name so constructing this message can never raise a second, uncaught
+        # exception (e.g. when the original failure was model_config.model_name itself
+        # raising AttributeError on a malformed config).
+        raise LCELModelException(
+            f"Unexpected error initialising model "
+            f"'{getattr(model_config, 'model_name', '<unknown>')}': {e}"
+        ) from e
+
+    # ── Manual provider-specific initialisation fallback (Azure and unsupported
+    # providers already handled above) ──────────────────────────────────────
+    api_key = _resolve_direct_api_key_(model_config)
+
     if model_config.provider == "openai":
-        # Check if this is Azure OpenAI based on api_base
-        api_base = getattr(model_config, "api_base", None)
-        is_azure = api_base and "openai.azure.com" in str(api_base)
-
-        if is_azure and hasattr(model_config, "api_version"):
-            # Azure OpenAI with direct API key
-            return AzureOpenAI(
-                model=model_config.model_name,
-                api_key=SecretStr(api_key),
-                azure_endpoint=api_base,
-                api_version=model_config.api_version,
-                model_kwargs={
-                    "engine": getattr(model_config, "engine", model_config.model_name),
-                    "api_version": model_config.api_version,
-                    "api_type": "azure",
-                },
-            )
-        else:
-            # Standard OpenAI
-            return ChatOpenAI(
-                model=model_config.model_name,
-                api_key=api_key,
-                base_url=api_base,  # Can be None for default OpenAI endpoint
-            )
+        return ChatOpenAI(
+            model=model_config.model_name,
+            api_key=api_key,
+            base_url=api_base,  # Can be None for default OpenAI endpoint
+            **_temperature_kwargs_(model_config),
+        )
 
     elif model_config.provider == "anthropic":
         try:
-            from langchain_anthropic import ChatAnthropic
+            from langchain_anthropic import ChatAnthropic  # pylint: disable=import-outside-toplevel
 
             return ChatAnthropic(
                 model=model_config.model_name,
                 anthropic_api_key=api_key,
                 anthropic_api_url=getattr(model_config, "api_base", None),
+                **_temperature_kwargs_(model_config),
             )
-        except ImportError:
-            raise LCELModelException(
+        except ImportError as exc:
+            raise LCELModelConfigError(
                 "langchain-anthropic not installed. Run: pip install langchain-anthropic"
-            )
+            ) from exc
 
     elif model_config.provider == "google":
         try:
-            from langchain_google_genai import ChatGoogleGenerativeAI
+            from langchain_google_genai import (  # pylint: disable=import-outside-toplevel
+                ChatGoogleGenerativeAI,
+            )
 
             return ChatGoogleGenerativeAI(
                 model=model_config.model_name,
                 google_api_key=api_key,
+                **_temperature_kwargs_(model_config),
             )
-        except ImportError:
-            raise LCELModelException(
+        except ImportError as exc:
+            raise LCELModelConfigError(
                 "langchain-google-genai not installed. Run: pip install langchain-google-genai"
-            )
+            ) from exc
 
     elif model_config.provider == "cohere":
         try:
-            from langchain_cohere import ChatCohere
+            from langchain_cohere import ChatCohere  # pylint: disable=import-outside-toplevel
 
             return ChatCohere(
                 model=model_config.model_name,
                 cohere_api_key=api_key,
+                **_temperature_kwargs_(model_config),
             )
-        except ImportError:
-            raise LCELModelException(
+        except ImportError as exc:
+            raise LCELModelConfigError(
                 "langchain-cohere not installed. Run: pip install langchain-cohere"
-            )
+            ) from exc
 
     elif model_config.provider == "huggingface":
         try:
-            from langchain_huggingface import HuggingFaceEndpoint
+            from langchain_huggingface import (  # pylint: disable=import-outside-toplevel
+                HuggingFaceEndpoint,
+            )
 
             return HuggingFaceEndpoint(
                 repo_id=model_config.model_name,
                 huggingfacehub_api_token=api_key,
                 endpoint_url=getattr(model_config, "api_base", None),
+                **_temperature_kwargs_(model_config),
             )
-        except ImportError:
-            raise LCELModelException(
+        except ImportError as exc:
+            raise LCELModelConfigError(
                 "langchain-huggingface not installed. Run: pip install langchain-huggingface"
-            )
+            ) from exc
 
-    else:
-        raise LCELModelException(
-            f"Provider '{model_config.provider}' not supported. "
-            f"Supported providers: openai, anthropic, google, cohere, huggingface"
-        )
+    # Defensive: fires only if a provider is added to _SUPPORTED_PROVIDERS without a
+    # matching branch above; also satisfies mypy's non-exhaustive-return check.
+    raise LCELModelConfigError(
+        f"No initialisation branch for provider '{model_config.provider}'"
+    )

--- a/connectchain/lcel/retry.py
+++ b/connectchain/lcel/retry.py
@@ -83,7 +83,9 @@ class LCELRetry(Runnable):
     # pylint: disable=W0622, W0221 # LangChain overrode input
     def invoke(self, input: Input, config: Optional[RunnableConfig] = None, **kwargs: Any) -> Any:
         return base_retry(
-            **self._get_kwargs_(self.runnable.invoke, kwargs={"input": input, "config": config})
+            **self._get_kwargs_(
+                self.runnable.invoke, kwargs={"input": input, "config": config, **kwargs}
+            )
         )
 
     # pylint: disable=W0622 # LangChain overrode input

--- a/connectchain/utils/config.py
+++ b/connectchain/utils/config.py
@@ -17,9 +17,39 @@ from typing import Any, Dict, Union
 
 import yaml
 
+from .exceptions import NonRetryableError
 
-class ConfigException(BaseException):
-    """Base exception for the config class"""
+
+class ConfigException(Exception, NonRetryableError):
+    """Base exception for the config class. A missing/malformed config file will never
+    succeed on retry -- see NonRetryableError."""
+
+
+def _require_key_(data: Any, key: str, owner: str) -> Any:
+    """Attribute-lookup core shared by Config and ConfigWrapper: validate that
+    `data` is a mapping containing `key` and return data[key].
+
+    Both failure modes raise AttributeError -- never KeyError or TypeError --
+    because AttributeError is the only exception type Python's own
+    optional-attribute tools understand: hasattr() returns False and
+    getattr(obj, key, default) returns the default ONLY for AttributeError;
+    anything else propagates as a crash out of those very calls.
+
+    * Non-mapping `data`: a YAML section left empty (e.g. a bare `eas:` line)
+      parses to None, and a scalar-valued section has no sub-keys to read.
+      `key in data` would raise TypeError on None (or silently do a substring
+      test on a str); a clear AttributeError instead makes such sections look
+      "attribute-less", which is what they are.
+    * Missing `key`: intentional strictness -- see ConfigWrapper's docstring.
+    """
+    if not isinstance(data, dict):
+        raise AttributeError(
+            f"Cannot read config key '{key}': {owner} holds "
+            f"{type(data).__name__} data, not a mapping"
+        )
+    if key not in data:
+        raise AttributeError(f"Config key '{key}' not found in {owner}")
+    return data[key]
 
 
 class Config:
@@ -40,28 +70,55 @@ class Config:
         return Config(config_path)
 
     def __getitem__(self, key: str) -> "ConfigWrapper":
-        """Get config item by key."""
+        """Get config item by key. Raises KeyError if absent (dict-style access
+        keeps dict-style errors)."""
         return ConfigWrapper(self.data[key])
 
     def __getattr__(self, key: str) -> "ConfigWrapper":
-        """Get config attribute by key."""
-        return ConfigWrapper(self.data[key])
+        """Get config attribute by key.
+
+        Raises AttributeError for a missing top-level key. (Formerly KeyError,
+        which broke hasattr()/getattr(default) on the root config object: they
+        only swallow AttributeError, so the KeyError escaped through them.)
+        Same strictness contract as ConfigWrapper.__getattr__ -- see its class
+        docstring."""
+        return ConfigWrapper(_require_key_(self.data, key, "Config"))
 
 
 class ConfigWrapper:
-    """Wrapper for Config Class"""
+    """Wrapper providing attribute- and item-style access to a parsed YAML
+    config tree (used for sections/models pulled out of Config).
+
+    Attribute access is STRICT by design: reading a key that is absent -- or
+    reading any key from a section whose data is not a mapping, e.g. a YAML
+    section left empty, which parses to None -- raises AttributeError. This is
+    intentional strictness so misconfigurations fail loudly at the point of
+    first use. The previous behavior of silently returning None for missing
+    keys defeated Python's optional-attribute tools for every consumer:
+    hasattr() was always True and getattr(obj, key, default) never returned
+    its default, so call sites could not distinguish "unset" from "set", and
+    misconfigurations surfaced as far-away crashes on unexpected Nones. With
+    AttributeError, hasattr()/getattr(default) genuinely work; use them for
+    keys that are legitimately optional.
+
+    Item access (wrapper["key"] / wrapper[0]) intentionally KEEPS the lenient
+    None-return for missing keys/indices: it is the explicit "give me the
+    value if present" accessor (e.g. `models[index]` followed by an is-None
+    check), and dict-style lookup has no hasattr()-style idiom for the
+    None-return to defeat.
+    """
 
     def __init__(self, data: Any) -> None:
         """Initialize config wrapper with data."""
         self.data = data
 
-    def __getattr__(self, key: str) -> Union["ConfigWrapper", Any, None]:
-        """Get attribute by key, returning None if not found."""
-        if key not in self.data:
-            return None
-        if isinstance(self.data[key], dict):
-            return ConfigWrapper(self.data[key])
-        return self.data[key]
+    def __getattr__(self, key: str) -> Union["ConfigWrapper", Any]:
+        """Get attribute by key; raises AttributeError if absent or if the
+        wrapped data is not a mapping (see class docstring)."""
+        value = _require_key_(self.data, key, "ConfigWrapper")
+        if isinstance(value, dict):
+            return ConfigWrapper(value)
+        return value
 
     def __getitem__(self, key: Union[str, int]) -> Union["ConfigWrapper", Any, None]:
         """Get item by key, returning None if not found."""

--- a/connectchain/utils/exceptions.py
+++ b/connectchain/utils/exceptions.py
@@ -12,9 +12,24 @@
 """ConnectChain exceptions."""
 
 
+class NonRetryableError:
+    """Marker mixin for exceptions that must never be retried.
+
+    connectchain.utils.retry's base_retry()/abase_retry() re-raise instances of this
+    immediately, even when they match the caller's `exceptions` filter (which defaults
+    to `Exception`). Use for permanent/config errors -- e.g. a missing environment
+    variable or unsupported provider will never succeed on retry, so retrying just
+    delays the inevitable failure and burns `max_retry` attempts on nothing.
+    """
+
+
 class OperationNotPermittedException(Exception):
     """Operation Not Permitted Exception"""
 
 
 class ConnectChainNoAccessException(BaseException):
-    """ConnectChain does not allow access to this class or method."""
+    """ConnectChain does not allow access to this class or method.
+
+    Deliberately not Exception: this enforces the APIChain security block in
+    connectchain/__init__.py, and must not be catchable by an ordinary
+    `except Exception` around application code wrapping a chain call."""

--- a/connectchain/utils/llm_proxy_wrapper.py
+++ b/connectchain/utils/llm_proxy_wrapper.py
@@ -11,11 +11,17 @@
 # the License.
 """Proxied LLM Utilities"""
 import functools
+import logging
 from typing import Any, Callable, List, Optional
 
-from langchain.llms import BaseLLM
+# BaseLLM only covers legacy completion models; all ConnectChain targets
+# (ChatOpenAI, ChatAnthropic, etc.) inherit from BaseChatModel, which shares
+# only the BaseLanguageModel base class.
+from langchain_core.language_models import BaseLanguageModel
 
 from .proxy_manager import ProxyConfig, ProxyManager
+
+logger = logging.getLogger(__name__)
 
 _llm_sync_methods_: List[str] = [
     "invoke",
@@ -50,7 +56,6 @@ def _sync_proxy_(func: Callable[..., Any], proxy_manager: ProxyManager) -> Calla
     def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         with proxy_manager.configure_proxy_sync():
             return func(self, *args, **kwargs)
-
     return wrapper
 
 
@@ -59,35 +64,42 @@ def _async_proxy_(func: Callable[..., Any], proxy_manager: ProxyManager) -> Call
     async def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
         with proxy_manager.configure_proxy_async():
             return await func(self, *args, **kwargs)
-
     return wrapper
 
 
 def _wrap_method_(
-    mixin: ProxyManager, llm: BaseLLM, method_name: str, decorator: Callable[..., Any]
+    mixin: ProxyManager, llm: BaseLanguageModel, method_name: str, decorator: Callable[..., Any]
 ) -> None:
-    """Langchain misuses pydantic so we must be careful accessing attributes even when we know they exist.
-    For the same reason, we must 'force-feed' the decorated function back to the class instance by setting
-    directly on the instance __dict__ to avoid pydantic validation.
+    """Langchain misuses pydantic so we must be careful accessing attributes even when we know
+    they exist.  For the same reason, we must 'force-feed' the decorated function back to the
+    class instance by setting directly on the instance __dict__ to avoid pydantic validation.
 
-    Note: pydantic is a data validation framework and is not intended to be used as an architecture validation
-    tool; despite the fact that it is used as such in Langchain."""
-    if hasattr(llm, method_name):
-        try:
-            func = getattr(llm, method_name)
-        except ValueError:
+    Note: pydantic is a data validation framework and is not intended to be used as an
+    architecture validation tool; despite the fact that it is used as such in Langchain."""
+    try:
+        if not hasattr(llm, method_name):
             return
-        wrapped_func = decorator(func, mixin)
-        llm.__dict__[method_name] = wrapped_func
+        func = getattr(llm, method_name)
+    except ValueError:
+        # hasattr()/getattr() can both trigger the same pydantic misbehavior this
+        # function's docstring warns about; either one raising means "skip it" --
+        # but say so: a silently unwrapped method means traffic bypasses the
+        # configured proxy with no visible trace otherwise.
+        logger.warning(
+            "Could not proxy-wrap method '%s' on %s (attribute access raised ValueError); "
+            "calls through this method will NOT use the configured proxy.",
+            method_name,
+            type(llm).__name__,
+        )
+        return
+    wrapped_func = decorator(func, mixin)
+    llm.__dict__[method_name] = wrapped_func
 
 
-def wrap_llm_with_proxy(llm: BaseLLM, proxy_config: Optional[ProxyConfig]) -> None:
+def wrap_llm_with_proxy(llm: BaseLanguageModel, proxy_config: Optional[ProxyConfig]) -> None:
     """Wrap an LLM instance with proxy functionality for network requests."""
-
     proxy_mixin = ProxyManager(proxy_config)
-
     decorator_pairs = [(_llm_sync_methods_, _sync_proxy_), (_llm_async_methods_, _async_proxy_)]
-
     for methods, decorator in decorator_pairs:
         for wrap_method_name in methods:
             _wrap_method_(proxy_mixin, llm, wrap_method_name, decorator)

--- a/connectchain/utils/retry.py
+++ b/connectchain/utils/retry.py
@@ -15,6 +15,33 @@ from functools import wraps
 from time import sleep
 from typing import Any, Awaitable, Callable, Dict, Optional, Tuple, Union
 
+from .exceptions import NonRetryableError
+
+
+def _fail_fast_(
+    error: BaseException,
+    exceptions: Union[Tuple[type[BaseException], ...], type[BaseException]],
+) -> bool:
+    """Whether a caught error should skip retries entirely.
+
+    NonRetryableError-marked exceptions fail fast under the default
+    `exceptions=Exception` filter -- a permanent/config error can never succeed
+    on retry. But a caller who EXPLICITLY lists a NonRetryableError-marked type
+    in `exceptions` has opted into retrying that family, and that explicit
+    request wins over the marker.
+
+    The opt-in is strictly PER-FAMILY: fail-fast is skipped only when the
+    caught error is an instance of an explicitly-listed type that is itself
+    NonRetryableError-marked. Listing one marked type (e.g.
+    `exceptions=(ConfigException, Exception)`) must not silently re-enable
+    retries for every other marked exception that merely matches a broader
+    entry like `Exception` -- those unrelated permanent errors still fail fast.
+    """
+    if not isinstance(error, NonRetryableError):
+        return False
+    exc_types = exceptions if isinstance(exceptions, tuple) else (exceptions,)
+    return not any(issubclass(t, NonRetryableError) and isinstance(error, t) for t in exc_types)
+
 
 def base_retry(  # pylint: disable=too-many-arguments, too-many-positional-arguments
     func: Callable[..., Any],
@@ -47,6 +74,10 @@ def base_retry(  # pylint: disable=too-many-arguments, too-many-positional-argum
         try:
             return func(*args, **kwargs)
         except exceptions as e:
+            if _fail_fast_(e, exceptions):
+                # Permanent/config error: matches `exceptions` but retrying it can
+                # never succeed, so fail fast instead of burning max_retry attempts.
+                raise
             attempt += 1
             next_sleep = sleep_time * (2 ** (attempt - 1)) if ebo else sleep_time
             if attempt < max_retry:
@@ -91,6 +122,8 @@ async def abase_retry(  # pylint: disable=too-many-arguments, too-many-positiona
         try:
             return await func(*args, **kwargs)
         except exceptions as e:
+            if _fail_fast_(e, exceptions):
+                raise
             attempt += 1
             next_sleep = sleep_time * (2 ** (attempt - 1)) if ebo else sleep_time
             if attempt < max_retry:

--- a/connectchain/utils/session_map.py
+++ b/connectchain/utils/session_map.py
@@ -10,6 +10,7 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 """This module is used to keep track of the session expiration time"""
+import threading
 from datetime import datetime
 from typing import Any, Dict, Optional, Tuple
 
@@ -17,43 +18,154 @@ from langchain.schema import LLMResult
 
 
 class SessionMap:
-    """This class is used to keep track of the session expiration time"""
+    """Singleton tracking session expiration time for cached LLM instances.
+
+    is_expired()/get_valid_llm() return safely for an unregistered
+    session_id rather than raising KeyError (get_llm() is the one
+    exception -- see its docstring). _instance_lock guards first
+    construction via double-checked locking; self._lock (created once
+    construction completes) guards all session_map reads/writes.
+    """
+
+    DEFAULT_EXPIRES_IN: int = 900
 
     _instance: Optional["SessionMap"] = None
-    session_map: Dict[str, Tuple[datetime, LLMResult]] = {}
-    expires_in: int = -1
+    _instance_lock: threading.Lock = threading.Lock()
+    _lock: threading.Lock
+    # Each entry stores the expires_in that was active when it was cached, not the
+    # singleton's current value -- a later SessionMap(different_interval) call must not
+    # retroactively change the expiry policy for sessions cached under a prior interval.
+    session_map: Dict[str, Tuple[datetime, int, LLMResult]] = {}
+    expires_in: int = DEFAULT_EXPIRES_IN
 
-    def __new__(cls, expires_in: int = 900) -> "SessionMap":
+    def __new__(cls, expires_in: Optional[int] = None) -> "SessionMap":
+        """Return the singleton, optionally reconfiguring its default expiry.
+
+        `expires_in=None` (the default) means "don't reconfigure": a bare
+        SessionMap() call -- e.g. constructed just to read the cache -- must not
+        silently reset a previously configured interval back to the default.
+        Passing an explicit value reconfigures the default used for sessions
+        cached from here on; already-cached sessions keep the expires_in they
+        were cached under (captured per-entry in new_session()).
+        """
         if cls._instance is None:
-            cls._instance = super(SessionMap, cls).__new__(cls)
-            cls._instance.expires_in = expires_in
+            with cls._instance_lock:
+                if cls._instance is None:
+                    # Fully build the instance on a local var before publishing it to
+                    # cls._instance. A racing thread's outer `if cls._instance is None`
+                    # check (above, outside the lock) reads cls._instance directly, so
+                    # publishing a partially-built instance (e.g. before _lock is set)
+                    # would let that thread skip the lock entirely and use an instance
+                    # missing _lock, raising AttributeError.
+                    new_instance = super(SessionMap, cls).__new__(cls)
+                    new_instance.expires_in = (
+                        expires_in if expires_in is not None else cls.DEFAULT_EXPIRES_IN
+                    )
+                    new_instance._lock = threading.Lock()
+                    cls._instance = new_instance
+                    return cls._instance
+        if expires_in is not None:
+            # Reconfigure only when the value actually changes. Every EAS-routed
+            # model() call constructs SessionMap(expires_in) on its hot path, and
+            # the value is almost always the one already configured, so
+            # unconditionally taking self._lock -- shared with every session_map
+            # cache read/write -- just to rewrite an identical int was pure lock
+            # contention. The preliminary comparison deliberately reads
+            # expires_in WITHOUT the lock: the read is a single atomic attribute
+            # fetch, and the worst a racing reconfiguration can do is make the
+            # comparison see the older or newer of two concurrently requested
+            # values -- the same last-writer-wins outcome the unconditional
+            # locked write had, so the benign race changes no observable
+            # semantics. The write itself stays locked so it cannot interleave
+            # with new_session()'s locked fallback read of self.expires_in.
+            if cls._instance.expires_in != expires_in:
+                with cls._instance._lock:
+                    cls._instance.expires_in = expires_in
         return cls._instance
 
-    def new_session(self, session_id: str, llm: LLMResult) -> None:
-        """save new session for later"""
-        self.session_map[session_id] = (datetime.now(), llm)
+    def new_session(
+        self, session_id: str, llm: LLMResult, expires_in: Optional[int] = None
+    ) -> None:
+        """Save new session for later.
+
+        Pass `expires_in` explicitly when the caller captured it before doing
+        anything slow (e.g. a network call): reading self.expires_in only at this
+        point would race a concurrent SessionMap(other_interval) call made by another
+        request in between, silently applying the wrong expiry to this session.
+        The None-fallback below is retained only for backward compatibility with
+        external callers; connectchain's own call sites always pass an explicit
+        int (resolving an unset config interval to DEFAULT_EXPIRES_IN at capture
+        time) precisely so this racy read is never exercised.
+        """
+        with self._lock:
+            if expires_in is None:
+                expires_in = self.expires_in
+            self.session_map[session_id] = (datetime.now(), expires_in, llm)
+
+    @staticmethod
+    def _is_stale(entry: Tuple[datetime, int, LLMResult]) -> bool:
+        """Whether a cached entry has exceeded the expires_in it was cached under.
+
+        Shared by is_expired() and get_valid_llm() so the staleness rule lives
+        in exactly one place. Pure function of the already-fetched entry tuple;
+        no lock needed.
+        """
+        cached_at, expires_in, _ = entry
+        return (datetime.now() - cached_at).total_seconds() > expires_in
 
     def is_expired(self, session_id: str) -> bool:
-        """check if the session is expired"""
-        return (datetime.now() - self.session_map[session_id][0]).total_seconds() > self.expires_in
+        """Check if the session is expired.
+
+        Returns True (treat as expired) when session_id is not yet registered
+        so that callers trigger a fresh token acquisition rather than raising
+        a KeyError.
+        """
+        with self._lock:
+            entry = self.session_map.get(session_id)
+            return entry is None or self._is_stale(entry)
 
     def get_llm(self, session_id: str) -> LLMResult:
-        """get the LLM instance from the session"""
-        return self.session_map[session_id][1]
+        """Get the LLM instance from the session.
+
+        Precondition: caller must confirm is_expired(session_id) returns
+        False first (or use get_valid_llm() instead, which does this
+        atomically). Raises KeyError if session_id is not registered.
+        """
+        with self._lock:
+            return self.session_map[session_id][2]
+
+    def get_valid_llm(self, session_id: str) -> Optional[LLMResult]:
+        """Return the cached LLM for session_id if it exists and is not expired,
+        else None. Checks existence and expiry atomically under one lock
+        acquisition, unlike calling is_expired() then get_llm() separately."""
+        with self._lock:
+            entry = self.session_map.get(session_id)
+            if entry is None or self._is_stale(entry):
+                return None
+            return entry[2]
 
     @staticmethod
     def uuid_from_config(config: Any, model_config: Any) -> str:
-        """generate a uuid from the config"""
-        env_id_key = None
-        env_secret_key = None
-        if model_config.eas:
-            env_id_key = model_config.eas.id_key
-            env_secret_key = model_config.eas.secret_key
+        """Generate a stable cache key from the config.
+
+        A partial per-model eas section overrides the global one key-by-key,
+        falling back to the global section for whichever keys it omits. Every
+        read here uses getattr's None default: this is a cache-key builder,
+        not a validator -- keys that are genuinely required are validated at
+        their point of use, and a missing optional key must keep rendering as
+        the literal "None" placeholder in the key (as it always has) rather
+        than raising now that Config/ConfigWrapper are strict about missing
+        attributes."""
+        model_eas = getattr(model_config, "eas", None)
+        env_id_key = getattr(model_eas, "id_key", None)
         if env_id_key is None:
-            env_id_key = config.eas.id_key
+            env_id_key = getattr(getattr(config, "eas", None), "id_key", None)
+        env_secret_key = getattr(model_eas, "secret_key", None)
         if env_secret_key is None:
-            env_secret_key = config.eas.secret_key
+            env_secret_key = getattr(getattr(config, "eas", None), "secret_key", None)
         env_uuid = f"{env_id_key}_{env_secret_key}"
-        model_uuid = f"{model_config.provider}_{model_config.type}_{model_config.engine}"
-        model_uuid += f"_{model_config.model_name}_{model_config.api_version}"
+        model_uuid = "_".join(
+            str(getattr(model_config, key, None))
+            for key in ("provider", "type", "engine", "model_name", "api_version")
+        )
         return f"{env_uuid}_{model_uuid}"

--- a/connectchain/utils/token_util.py
+++ b/connectchain/utils/token_util.py
@@ -26,6 +26,7 @@ from dotenv import find_dotenv, load_dotenv
 from OpenSSL import crypto as c
 
 from connectchain.utils import Config
+from connectchain.utils.exceptions import NonRetryableError
 
 # There are 3 environment variables that need to be set: CONFIG_PATH:
 # path to the config file Consumer ID: the consumer integration ID.
@@ -35,8 +36,21 @@ from connectchain.utils import Config
 # defined in the config file under eas.secret_key
 
 
-class UtilException(BaseException):
-    """Custom exception class for token_util"""
+class UtilException(Exception, NonRetryableError):
+    """Custom exception class for token_util. Raised for permanent config errors
+    (missing models, undefined index, unset env keys, expired cert) that can
+    never succeed on retry -- see NonRetryableError."""
+
+
+class EASAuthError(Exception):
+    """Raised when a call to the EAS auth service fails (any non-200 response).
+
+    Deliberately a plain, retry-eligible Exception -- NOT a UtilException --
+    because the retryability of an auth-service failure is unknown at raise
+    time: a transient 5xx or throttling response may well succeed on retry.
+    UtilException carries the NonRetryableError marker (it is reserved for
+    permanent config errors), so raising it here would make retry-wrapped
+    token fetches fail fast on recoverable server errors."""
 
 
 def get_token_from_env(index: Any = "1") -> str:
@@ -44,25 +58,29 @@ def get_token_from_env(index: Any = "1") -> str:
     config = Config.from_env()
     try:
         models = config.models
-    except KeyError as ex:
+    except AttributeError as ex:
+        # Config raises AttributeError for a missing top-level key.
         raise UtilException("No models defined in config") from ex
     model_config = models[index]
     if model_config is None:
         raise UtilException(f'Model config at index "{index}" is not defined')
-    consumer_id_key = None
-    consumer_secret_key = None
-    if model_config.eas:
-        consumer_id_key = model_config.eas.id_key
-        consumer_secret_key = model_config.eas.secret_key
+    # A partial per-model eas section overrides the global one key-by-key; each
+    # key is therefore optional at each level, hence getattr's None defaults
+    # (missing keys raise AttributeError now). The global `config.eas` section
+    # itself stays a strict read: reaching the fallback without one is a real
+    # misconfiguration that should fail loudly.
+    model_eas = getattr(model_config, "eas", None)
+    consumer_id_key = getattr(model_eas, "id_key", None)
+    consumer_secret_key = getattr(model_eas, "secret_key", None)
     if consumer_id_key is None:
-        consumer_id_key = config.eas.id_key
+        consumer_id_key = getattr(config.eas, "id_key", None)
     consumer_id = os.getenv(f"{consumer_id_key}")
     if consumer_id is None:
         raise UtilException(
             f'Environment variable id key "{consumer_id_key}" not set for model index {index}'
         )
     if consumer_secret_key is None:
-        consumer_secret_key = config.eas.secret_key
+        consumer_secret_key = getattr(config.eas, "secret_key", None)
     consumer_secret = os.getenv(f"{consumer_secret_key}")
     if consumer_secret is None:
         raise UtilException(
@@ -86,19 +104,23 @@ class TokenUtil:
 
     def __retrieve_cert(self, model_config: Any) -> None:
         """retrieve certificate from the url in the config file if it does not exist locally"""
-        cert_path = None
-        cert_name = None
-        cert_size = None
-        if model_config.cert:
-            cert_path = model_config.cert.cert_path
-            cert_name = model_config.cert.cert_name
-            cert_size = model_config.cert.cert_size
+        # Per-model cert settings override the global ones key-by-key, and every
+        # key is optional at each level (the guards below skip whatever is
+        # unset), hence getattr's None defaults throughout. The global
+        # `self.config.cert` section reads stay strict on purpose: they are
+        # only reached when a key is otherwise unresolved, and a missing global
+        # cert section then fails loudly rather than silently skipping cert
+        # verification.
+        model_cert = getattr(model_config, "cert", None)
+        cert_path = getattr(model_cert, "cert_path", None)
+        cert_name = getattr(model_cert, "cert_name", None)
+        cert_size = getattr(model_cert, "cert_size", None)
         if cert_path is None:
-            cert_path = self.config.cert.cert_path
+            cert_path = getattr(self.config.cert, "cert_path", None)
         if cert_name is None:
-            cert_name = self.config.cert.cert_name
+            cert_name = getattr(self.config.cert, "cert_name", None)
         if cert_size is None:
-            cert_size = self.config.cert.cert_size
+            cert_size = getattr(self.config.cert, "cert_size", None)
         if cert_path and cert_name:
             urllib.request.urlretrieve(str(cert_path), str(cert_name))
         # check whether the certificate exists locally
@@ -126,15 +148,15 @@ class TokenUtil:
 
     def __service_payload(self, model_config: Any) -> Dict[str, Any]:
         """payload to get the bearer token"""
-        scope = None
-        originator_source = None
-        if model_config.eas:
-            scope = model_config.eas.scope
-            originator_source = model_config.eas.originator_source
+        # Same per-model-overrides-global, key-by-key optionality as elsewhere
+        # in this module, hence getattr's None defaults.
+        model_eas = getattr(model_config, "eas", None)
+        scope = getattr(model_eas, "scope", None)
+        originator_source = getattr(model_eas, "originator_source", None)
         if scope is None:
-            scope = self.config.eas.scope
+            scope = getattr(self.config.eas, "scope", None)
         if originator_source is None:
-            originator_source = self.config.eas.originator_source
+            originator_source = getattr(self.config.eas, "originator_source", None)
         return {"scope": scope, "additional_claims": {"originator_source": originator_source}}
 
     @staticmethod
@@ -181,7 +203,10 @@ class TokenUtil:
     def __response_builder(out: Any, status_code: int) -> str:
         if status_code == 200:
             return f"Bearer {out['authorization_token']}"
-        raise UtilException(out["description"])
+        # Non-200 from the auth service may be transient (5xx, throttling), so
+        # raise the retry-eligible EASAuthError rather than the
+        # NonRetryableError-marked UtilException -- see EASAuthError.
+        raise EASAuthError(out["description"])
 
     def __get_signature(self, version: str, timestamp: int) -> str:
         message = f"{self.consumer_id}-{version}-{str(timestamp)}"
@@ -195,11 +220,11 @@ class TokenUtil:
 
     async def get_token(self, model_config: Any) -> str:
         """async method to get the bearer token"""
-        cert_name = None
-        if model_config.cert:
-            cert_name = model_config.cert.cert_name
+        # Per-model override falls back to the global cert section (see
+        # __retrieve_cert for why the reads use getattr's None default).
+        cert_name = getattr(getattr(model_config, "cert", None), "cert_name", None)
         if cert_name is None:
-            cert_name = self.config.cert.cert_name
+            cert_name = getattr(self.config.cert, "cert_name", None)
         if cert_name and not os.path.exists(str(cert_name)):
             self.__retrieve_cert(model_config)
         correlation_id = uuid.uuid1().hex
@@ -207,11 +232,10 @@ class TokenUtil:
         timestamp = int(time.time() * 1000.0)
         signature = self.__get_signature(version, timestamp)
         sor_name = "dummy"
-        eas_url = None
-        if model_config.eas:
-            eas_url = model_config.eas.url
+        # Per-model override falls back to the global eas section, key-by-key.
+        eas_url = getattr(getattr(model_config, "eas", None), "url", None)
         if eas_url is None:
-            eas_url = self.config.eas.url
+            eas_url = getattr(self.config.eas, "url", None)
         timeout = 5
 
         response = await TokenUtil.__aio_http_post(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,13 @@ dependencies = [
     "openai>=1.0.0",
     "pyyaml==6.0.1",
     "SQLAlchemy==2.0.22",
-    "langchain>=0.3.26",
-    "langchain-openai>=0.3.24",
-    "langchain-community>=0.3.26",
+    "langchain>=0.3.26,<0.4.0",
+    "langchain-openai>=0.3.24,<0.4.0",
+    "langchain-community>=0.3.26,<0.4.0",
     "tiktoken>=0.7.0",
     "python-dotenv~=1.0.0",
     "pyopenssl==23.3.0",
-    "langchain-mcp-adapters>=0.1.0",
+    "langchain-mcp-adapters>=0.1.0,<0.2.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit_tests/test_api_chain_block.py
+++ b/tests/unit_tests/test_api_chain_block.py
@@ -1,0 +1,38 @@
+# Copyright 2023 American Express Travel Related Services Company, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+"""Unit testing for the APIChain security block and its exception type"""
+import unittest
+
+from langchain.chains.api.base import APIChain
+
+import connectchain  # noqa: F401  pylint: disable=unused-import
+from connectchain.utils.exceptions import ConnectChainNoAccessException
+
+
+class TestAPIChainBlock(unittest.TestCase):
+    """ConnectChainNoAccessException must not be catchable by a generic except Exception,
+    since it enforces a deliberate security block on APIChain."""
+
+    def test_not_a_subclass_of_exception(self):
+        """The security block must survive an ordinary except Exception around it"""
+        self.assertFalse(issubclass(ConnectChainNoAccessException, Exception))
+        self.assertTrue(issubclass(ConnectChainNoAccessException, BaseException))
+
+    def test_api_chain_raises_and_is_not_swallowed_by_except_exception(self):
+        """Simulates application code wrapping a chain call in except Exception"""
+        with self.assertRaises(ConnectChainNoAccessException):
+            try:
+                APIChain.run(None, "some query")
+            except Exception:  # pylint: disable=broad-except
+                self.fail(
+                    "ConnectChainNoAccessException must not be caught by except Exception"
+                )

--- a/tests/unit_tests/test_config.py
+++ b/tests/unit_tests/test_config.py
@@ -16,6 +16,7 @@ import os
 import unittest
 
 from connectchain.utils import Config
+from connectchain.utils.config import ConfigWrapper
 
 # pylint: disable=invalid-name duplicate-code
 mock_config = """
@@ -54,3 +55,110 @@ class TestConfig(unittest.TestCase):
         self.assertEqual(config.cert.cert_name, "./some_cert.crt")
         # remove mock config.yml file
         os.remove("mock_config.yml")
+
+
+class TestConfigWrapperStrictness(unittest.TestCase):
+    """Regression suite for the deliberate ConfigWrapper strictness change:
+    attribute access on a missing key raises AttributeError instead of
+    silently returning None. The old None-return defeated hasattr() (always
+    True) and getattr(obj, key, default) (default never returned) for every
+    consumer; these tests pin the new contract down."""
+
+    def test_missing_key_raises_attribute_error_naming_the_key(self):
+        """A missing key must raise AttributeError (so misconfigurations fail
+        loudly at first use) and the message must name the offending key."""
+        wrapper = ConfigWrapper({"present": 1})
+        with self.assertRaisesRegex(AttributeError, "missing_key"):
+            _ = wrapper.missing_key
+
+    def test_hasattr_reflects_actual_key_presence(self):
+        """hasattr() was previously True for EVERY key (None-return); it must
+        now genuinely reflect presence."""
+        wrapper = ConfigWrapper({"present": 1})
+        self.assertTrue(hasattr(wrapper, "present"))
+        self.assertFalse(hasattr(wrapper, "absent"))
+
+    def test_getattr_default_is_honored(self):
+        """getattr's default was previously dead code (None always returned);
+        it must now be returned for missing keys, while present keys still
+        resolve to their values."""
+        wrapper = ConfigWrapper({"present": 1})
+        self.assertEqual(getattr(wrapper, "present", "default"), 1)
+        self.assertEqual(getattr(wrapper, "absent", "default"), "default")
+        self.assertIsNone(getattr(wrapper, "absent", None))
+
+    def test_nested_wrapper_behavior(self):
+        """Dict values come back wrapped (so the strict contract applies at
+        every nesting level); scalars come back raw; a missing nested key
+        raises just like a missing top-level one."""
+        wrapper = ConfigWrapper({"section": {"key": "value"}})
+        nested = wrapper.section
+        self.assertIsInstance(nested, ConfigWrapper)
+        self.assertEqual(nested.key, "value")
+        with self.assertRaisesRegex(AttributeError, "other_key"):
+            _ = nested.other_key
+        self.assertFalse(hasattr(nested, "other_key"))
+
+    def test_none_data_raises_clear_attribute_error_not_type_error(self):
+        """A YAML section left empty (e.g. a bare `eas:` line) parses to None.
+        Attribute access on such a wrapper used to crash with TypeError
+        ("argument of type 'NoneType' is not iterable" from `key in None`);
+        it must now raise a clear AttributeError -- which also means
+        hasattr()/getattr(default) treat the empty section as attribute-less
+        instead of blowing up."""
+        wrapper = ConfigWrapper(None)
+        with self.assertRaisesRegex(AttributeError, "id_key"):
+            _ = wrapper.id_key
+        self.assertFalse(hasattr(wrapper, "id_key"))
+        self.assertIsNone(getattr(wrapper, "id_key", None))
+
+    def test_non_mapping_data_raises_attribute_error(self):
+        """Scalar- and list-valued sections have no sub-keys to read: attribute
+        access must raise AttributeError (a str used to be substring-probed by
+        `key in data`; a list raised TypeError)."""
+        for data in ("scalar-value", [1, 2, 3], 42):
+            with self.subTest(data=data):
+                wrapper = ConfigWrapper(data)
+                with self.assertRaisesRegex(AttributeError, "some_key"):
+                    _ = wrapper.some_key
+                self.assertFalse(hasattr(wrapper, "some_key"))
+
+    def test_item_access_stays_lenient(self):
+        """The strictness change is scoped to ATTRIBUTE access only: item
+        access is the explicit optional accessor (e.g. models[index] followed
+        by an is-None check) and must keep returning None for missing keys
+        and out-of-range list indices."""
+        wrapper = ConfigWrapper({"present": 1, "items": [10]})
+        self.assertIsNone(wrapper["absent"])
+        self.assertEqual(wrapper["present"], 1)
+        self.assertIsNone(ConfigWrapper([10])[5])
+
+    def test_config_missing_top_level_key_raises_attribute_error(self):
+        """Config.__getattr__ used to raise KeyError for a missing top-level
+        key, which escaped straight through hasattr()/getattr(default) (they
+        only swallow AttributeError). It must now follow the same
+        AttributeError contract as ConfigWrapper so those idioms work on the
+        root config object too (e.g. getattr(config, "proxy", None))."""
+        with open("mock_config_strict.yml", "w", encoding="utf-8") as f:
+            f.write(mock_config)
+        self.addCleanup(os.remove, "mock_config_strict.yml")
+        config = Config("mock_config_strict.yml")
+        with self.assertRaisesRegex(AttributeError, "proxy"):
+            _ = config.proxy
+        self.assertFalse(hasattr(config, "proxy"))
+        self.assertIsNone(getattr(config, "proxy", None))
+        self.assertTrue(hasattr(config, "eas"))
+
+    def test_empty_yaml_section_is_treated_as_attribute_less(self):
+        """End-to-end through Config: a section present but empty (`proxy:`)
+        wraps None; reading keys from it raises AttributeError (not TypeError)
+        so presence probes via getattr/hasattr degrade gracefully."""
+        with open("mock_config_empty_section.yml", "w", encoding="utf-8") as f:
+            f.write(mock_config + "\nproxy:\n")
+        self.addCleanup(os.remove, "mock_config_empty_section.yml")
+        config = Config("mock_config_empty_section.yml")
+        empty_section = config.proxy  # present, wraps None
+        self.assertIsInstance(empty_section, ConfigWrapper)
+        with self.assertRaisesRegex(AttributeError, "host"):
+            _ = empty_section.host
+        self.assertIsNone(getattr(empty_section, "host", None))

--- a/tests/unit_tests/test_model.py
+++ b/tests/unit_tests/test_model.py
@@ -10,6 +10,7 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 """Unit testing for PortableOrchestrator class"""
+
 import os
 import unittest
 from unittest.mock import Mock, patch
@@ -17,7 +18,11 @@ from unittest.mock import Mock, patch
 from langchain_openai import AzureOpenAI, ChatOpenAI
 
 from connectchain.lcel import LCELModelException, model
-from .setup_utils import get_mock_config
+from connectchain.lcel.model import LCELModelConfigError, _get_direct_model_
+from connectchain.utils import SessionMap
+from connectchain.utils.exceptions import NonRetryableError
+
+from .setup_utils import get_mock_config, wrap_model_config
 
 
 class TestModel(unittest.TestCase):
@@ -65,6 +70,44 @@ class TestModel(unittest.TestCase):
         test_token = os.getenv("TEST_MODEL_ENV")
         self.assertEqual(test_token, "test_token")
 
+    def test_model_without_eas_section_routes_direct(self):
+        """A config with NO eas section at all must route to the direct
+        (non-EAS) path instead of crashing: now that Config raises
+        AttributeError for missing top-level keys, the routing check probes
+        the section via getattr defaults, which genuinely work."""
+        test_config = get_mock_config()
+        del test_config.data["eas"]
+        mocks = self.setUpWithConfig(test_config)
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            test_model = model()
+        self.assertIsInstance(test_model, ChatOpenAI)
+        mocks["token"].assert_not_called()
+
+    def test_model_with_empty_eas_section_routes_direct(self):
+        """A bare `eas:` line in YAML parses to None. Attribute access on the
+        wrapped None section raises AttributeError (formerly TypeError, which
+        blew through the routing check's except clause), so the getattr-based
+        probe must degrade to direct routing."""
+        test_config = get_mock_config()
+        test_config.data["eas"] = None
+        mocks = self.setUpWithConfig(test_config)
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            test_model = model()
+        self.assertIsInstance(test_model, ChatOpenAI)
+        mocks["token"].assert_not_called()
+
+    def test_model_with_eas_section_missing_id_key_routes_direct(self):
+        """An eas section without an id_key cannot authenticate through EAS, so
+        the model must route direct -- getattr's default (now honored for
+        missing ConfigWrapper keys) is what makes this presence check work."""
+        test_config = get_mock_config()
+        test_config.data["eas"] = {"secret_key": "secret_key"}
+        mocks = self.setUpWithConfig(test_config)
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            test_model = model()
+        self.assertIsInstance(test_model, ChatOpenAI)
+        mocks["token"].assert_not_called()
+
     def test_model_with_no_models_configured(self):
         test_config = get_mock_config()
         del test_config.data["models"]
@@ -80,19 +123,490 @@ class TestModel(unittest.TestCase):
             test_model = model("gpt5")
 
     def test_model_with_unsupported_provider(self):
+        """SYSTEMATIC-DEBUGGING FIX: unsupported provider must fail fast with the
+        'not supported' message, not a misleading 'API key not found' error from
+        an unrelated env var that the caller was never going to set. This also
+        fixes a stale assertion: the actual message has always said 'not
+        supported', never 'Not implemented' — the regex could not have matched
+        even if the ordering bug were absent."""
         test_config = get_mock_config()
         # required to not modify dict instance
         test_config.data["models"]["1"] = {**test_config.data["models"]["1"]}
         test_config.data["models"]["1"]["provider"] = "meta"
         self.setUpWithConfig(test_config)
-        with self.assertRaisesRegex(LCELModelException, "Not implemented") as _:
+        with self.assertRaisesRegex(LCELModelException, "not supported") as _:
             test_model = model()
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_get_direct_model_reraises_unexpected_exception(self, mock_init_chat_model):
+        """BUG-4 regression: an unexpected exception from init_chat_model() (anything
+        other than ImportError/ValueError) must be re-raised as LCELModelException with
+        the original exception preserved via `from e`, not silently swallowed by a bare
+        `except: pass` and left to fall through to manual init."""
+        mock_init_chat_model.side_effect = RuntimeError("boom: unexpected failure")
+        model_config = wrap_model_config(get_mock_config().data["models"]["1"])
+        with self.assertRaisesRegex(
+            LCELModelException, "Unexpected error initialising model"
+        ) as cm:
+            _get_direct_model_(model_config)
+        # confirm the original exception is chained, not lost
+        self.assertIsInstance(cm.exception.__cause__, RuntimeError)
+        # CODE-REVIEW regression: the wrapped error's retryability is unknown (it
+        # could be a transient network/provider failure), so it must be the plain
+        # base class -- NOT NonRetryableError-marked -- leaving retry wrappers free
+        # to retry it.
+        self.assertNotIsInstance(cm.exception, NonRetryableError)
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_get_direct_model_falls_through_on_expected_exceptions(self, mock_init_chat_model):
+        """BUG-4 regression: expected ImportError/ValueError from init_chat_model() must
+        still fall through to manual provider init (not be re-raised)."""
+        mock_init_chat_model.side_effect = ValueError("Unable to infer model provider")
+        model_config = wrap_model_config(get_mock_config().data["models"]["1"])
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            result = _get_direct_model_(model_config)
+        self.assertIsInstance(result, ChatOpenAI)
+
+    def test_get_direct_model_safe_message_when_model_name_raises(self):
+        """If the original failure inside _get_direct_model_'s try block was itself
+        model_config.model_name raising AttributeError (a malformed config missing
+        that attribute), the except-Exception handler's error message must not
+        re-access that same attribute -- doing so would raise a second, uncaught
+        AttributeError instead of the intended clean LCELModelException."""
+
+        class _ModelNameRaises:
+            provider = "openai"
+
+            @property
+            def model_name(self):
+                raise AttributeError("model_name is not available")
+
+        with self.assertRaisesRegex(
+            LCELModelException, "Unexpected error initialising model"
+        ) as cm:
+            _get_direct_model_(_ModelNameRaises())
+        self.assertIsInstance(cm.exception.__cause__, AttributeError)
+
+    @patch("connectchain.lcel.model.logger")
+    def test_unsupported_provider_does_not_log_fallback_warning(self, mock_logger):
+        """A genuinely unknown provider must fail with the clear 'not supported' error
+        WITHOUT first emitting the misleading 'falling back to manual provider init'
+        warning -- there is no manual branch for it, so there is nothing to fall back
+        to. Uses the REAL init_chat_model(): the provider name is passed through to it
+        explicitly and its 'Unsupported model_provider' ValueError is what gets
+        re-raised as the not-supported LCELModelConfigError."""
+        model_config = wrap_model_config(
+            {**get_mock_config().data["models"]["1"], "provider": "meta"}
+        )
+        with self.assertRaisesRegex(LCELModelConfigError, "not supported") as cm:
+            _get_direct_model_(model_config)
+        # The chained cause is init_chat_model()'s own rejection of the provider.
+        self.assertIsInstance(cm.exception.__cause__, ValueError)
+        mock_logger.warning.assert_not_called()
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_provider_without_manual_branch_reaches_init_chat_model_fast_path(
+        self, mock_init_chat_model
+    ):
+        """CODE-REVIEW regression: providers outside the manual fallback set
+        (mistralai, groq, ollama, bedrock, ...) are fully served by the
+        init_chat_model() fast path and must NOT be pre-emptively rejected by the
+        _SUPPORTED_PROVIDERS check -- that gate exists only for the manual fallback.
+        The configured provider must be passed to init_chat_model() explicitly
+        (model_provider=...) so a bogus provider still fails clearly there instead
+        of silently constructing whatever model the name happens to infer to."""
+        model_config = wrap_model_config(
+            {"provider": "mistralai", "model_name": "mistral-large-latest"}
+        )
+        result = _get_direct_model_(model_config)
+        self.assertIs(result, mock_init_chat_model.return_value)
+        self.assertEqual(
+            mock_init_chat_model.call_args.kwargs["model_provider"], "mistralai"
+        )
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_manual_set_provider_does_not_pass_model_provider(self, mock_init_chat_model):
+        """Providers in the manual fallback set keep the baseline inference-based
+        init_chat_model() call (no model_provider kwarg): e.g. 'google' is a valid
+        connectchain provider but NOT a valid init_chat_model provider id
+        (google_genai/google_vertexai), so passing it through would break a
+        previously working path."""
+        model_config = wrap_model_config({"provider": "openai", "model_name": "gpt-4"})
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            _get_direct_model_(model_config)
+        self.assertNotIn("model_provider", mock_init_chat_model.call_args.kwargs)
+
+    def test_exception_hierarchy_retryability_split(self):
+        """CODE-REVIEW regression: LCELModelException must be plain (retry-eligible)
+        because it also wraps UNEXPECTED init failures of unknown retryability;
+        only LCELModelConfigError -- raised for known-permanent config problems --
+        carries the NonRetryableError marker. The subclass relationship keeps
+        `except LCELModelException` catching both."""
+        self.assertFalse(issubclass(LCELModelException, NonRetryableError))
+        self.assertTrue(issubclass(LCELModelConfigError, LCELModelException))
+        self.assertTrue(issubclass(LCELModelConfigError, NonRetryableError))
+
+    def test_permanent_config_errors_are_non_retryable(self):
+        """Representative known-permanent raise sites must use LCELModelConfigError
+        (NonRetryableError) so retry wrappers fail fast on them."""
+        # Unsupported provider.
+        with self.assertRaises(LCELModelConfigError) as cm:
+            _get_direct_model_(
+                wrap_model_config({"provider": "meta", "model_name": "test_model"})
+            )
+        self.assertIsInstance(cm.exception, NonRetryableError)
+        # Azure endpoint with missing api_version.
+        with self.assertRaises(LCELModelConfigError) as cm:
+            _get_direct_model_(
+                wrap_model_config(
+                    {
+                        "provider": "openai",
+                        "model_name": "gpt-4",
+                        "api_base": "https://my-resource.openai.azure.com/",
+                    }
+                )
+            )
+        self.assertIsInstance(cm.exception, NonRetryableError)
+
+    def test_model_azure_endpoint_without_api_version_raises(self):
+        """An Azure-shaped api_base without api_version must fail loudly instead of
+        silently falling back to a non-Azure ChatOpenAI client pointed at Azure."""
+        test_config = get_mock_config()
+        test_config.data["models"]["1"] = {**test_config.data["models"]["1"]}
+        test_config.data["models"]["1"]["bypass_eas"] = True
+        test_config.data["models"]["1"]["api_base"] = "https://my-resource.openai.azure.com/"
+        del test_config.data["models"]["1"]["api_version"]
+        self.setUpWithConfig(test_config)
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test_key"}):
+            with self.assertRaisesRegex(LCELModelException, "api_version is required") as _:
+                test_model = model()
+
+    def test_model_entrypoint_azure_realistic_model_name_without_api_version_raises(self):
+        """Regression test: a realistic model_name (e.g. "gpt-4") makes
+        langchain.chat_models.init_chat_model() succeed and return early on the fast
+        path, so the api_version guard must fire BEFORE that path is even attempted --
+        not only in the manual fallback branch reached when the fast path fails (which
+        is all test_model_azure_endpoint_without_api_version_raises above exercised,
+        via the fixture's non-standard model_name="test_model").
+
+        This variant drives the full model() entry point (including bypass_eas
+        routing into _get_direct_model_); its sibling
+        test_model_azure_endpoint_realistic_model_name_without_api_version_raises
+        below calls _get_direct_model_ directly. (Both previously shared one name,
+        so Python silently discarded this one -- a dead test.)"""
+        test_config = get_mock_config()
+        test_config.data["models"]["1"] = {**test_config.data["models"]["1"]}
+        test_config.data["models"]["1"]["bypass_eas"] = True
+        test_config.data["models"]["1"]["model_name"] = "gpt-4"
+        test_config.data["models"]["1"]["api_base"] = "https://my-resource.openai.azure.com/"
+        del test_config.data["models"]["1"]["api_version"]
+        self.setUpWithConfig(test_config)
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test_key"}):
+            with self.assertRaisesRegex(LCELModelException, "api_version is required") as _:
+                test_model = model()
 
     def test_use_of_session_map(self):
         self.setUpWithConfig(get_mock_config())
         test_model = model()
         test_model2 = model()
         self.assertIs(test_model, test_model2)
+
+    @patch("connectchain.lcel.model.ChatOpenAI", return_value=Mock(ChatOpenAI))
+    # pylint: disable=unused-argument
+    def test_unset_token_refresh_interval_resolved_before_network_call(self, *args):
+        """CODE-REVIEW regression: when config.eas.token_refresh_interval is unset
+        (the model() path resolves the missing key to None via getattr's default),
+        the expiry interval must be
+        resolved to SessionMap.DEFAULT_EXPIRES_IN at capture time -- BEFORE
+        get_token_from_env()'s network call -- and passed to new_session() as an
+        explicit int. Passing None through would make new_session() fall back to the
+        singleton's CURRENT expires_in after the network call, inheriting whatever
+        interval a concurrent request configured last: the exact race the
+        capture-before-I/O comment in _get_openai_model_ claims to close."""
+        test_config = get_mock_config()
+        test_config.data["eas"] = {**test_config.data["eas"]}
+        del test_config.data["eas"]["token_refresh_interval"]
+        mocks = self.setUpWithConfig(test_config)
+
+        # Fresh singleton state for this test; reset again afterwards so the
+        # class-level singleton/cache never leaks into other tests.
+        def _reset_singleton():
+            SessionMap._instance = None  # pylint: disable=protected-access
+            SessionMap.session_map.clear()
+
+        _reset_singleton()
+        self.addCleanup(_reset_singleton)
+
+        def token_with_concurrent_reconfig(_index):
+            # Simulate another request reconfiguring the singleton for a different
+            # model's (much shorter) interval while this request is mid-network-call.
+            SessionMap(5)
+            return "test_token"
+
+        mocks["token"].side_effect = token_with_concurrent_reconfig
+        model()
+        cached_expires_in = SessionMap.session_map["TEST_MODEL_ENV"][1]
+        self.assertEqual(cached_expires_in, SessionMap.DEFAULT_EXPIRES_IN)
+
+    def test_direct_azure_model_does_not_supply_api_version_twice(self):
+        """Regression test: _get_direct_model_'s Azure branch must construct a real
+        (non-mocked) AzureOpenAI without pydantic rejecting api_version as supplied
+        twice (once as a direct kwarg, once inside model_kwargs)."""
+        model_config = wrap_model_config(
+            {
+                "provider": "openai",
+                "model_name": "gpt-4",
+                "api_base": "https://my-resource.openai.azure.com/",
+                "api_version": "2024-02-01",
+                "engine": "gpt-4",
+            }
+        )
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            result = _get_direct_model_(model_config)
+        self.assertIsInstance(result, AzureOpenAI)
+
+    def test_model_azure_endpoint_realistic_model_name_without_api_version_raises(self):
+        """Regression test: a realistic model_name (e.g. "gpt-4") makes
+        langchain.chat_models.init_chat_model() succeed and return early on the fast
+        path, so the api_version guard must fire BEFORE that path is even attempted --
+        not only in the manual fallback branch reached when the fast path fails."""
+        model_config = wrap_model_config(
+            {
+                "provider": "openai",
+                "model_name": "gpt-4",
+                "api_base": "https://my-resource.openai.azure.com/",
+            }
+        )
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            with self.assertRaisesRegex(LCELModelException, "api_version is required") as _:
+                _get_direct_model_(model_config)
+
+    def test_sovereign_cloud_azure_endpoint_detected(self):
+        """CODE-REVIEW regression: Azure US Government / China endpoints
+        (openai.azure.us, openai.azure.cn) must route to the Azure builder like the
+        public cloud, not silently fall through to a plain ChatOpenAI."""
+        for host in ("openai.azure.us", "openai.azure.cn"):
+            with self.subTest(host=host):
+                model_config = wrap_model_config(
+                    {
+                        "provider": "openai",
+                        "model_name": "gpt-4",
+                        "api_base": f"https://my-resource.{host}/",
+                    }
+                )
+                with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+                    # Reaching the api_version guard proves Azure routing happened.
+                    with self.assertRaisesRegex(LCELModelException, "api_version is required"):
+                        _get_direct_model_(model_config)
+
+    def test_explicit_azure_flag_forces_azure_routing(self):
+        """CODE-REVIEW regression: APIM/custom domains can't be detected by hostname;
+        `azure: true` on the model config must force Azure routing explicitly."""
+        model_config = wrap_model_config(
+            {
+                "provider": "openai",
+                "model_name": "gpt-4",
+                "api_base": "https://llm-gw.mycorp.example/",
+                "azure": True,
+            }
+        )
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            with self.assertRaisesRegex(LCELModelException, "api_version is required"):
+                _get_direct_model_(model_config)
+
+    def test_azure_lookalike_urls_are_not_misrouted_to_azure(self):
+        """CODE-REVIEW regression: Azure detection must suffix-match the parsed
+        HOSTNAME, not substring-match the whole URL. A URL carrying an Azure marker
+        in its path, or a lookalike host merely containing a marker, must build a
+        plain ChatOpenAI -- misrouting to the Azure builder would surface here as
+        the 'api_version is required' guard firing (no api_version is configured)."""
+        for api_base in (
+            "https://myproxy.corp.com/openai.azure.com-compat",
+            "https://notopenai.azure.com.evil.example/v1",
+        ):
+            with self.subTest(api_base=api_base):
+                model_config = wrap_model_config(
+                    {
+                        "provider": "openai",
+                        "model_name": "gpt-4",
+                        "api_base": api_base,
+                    }
+                )
+                with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+                    result = _get_direct_model_(model_config)
+                self.assertIsInstance(result, ChatOpenAI)
+
+    def test_schemeless_azure_api_base_still_detected(self):
+        """A scheme-less api_base on a real Azure domain must still route to the
+        Azure builder: urlparse() puts a scheme-less value entirely in .path
+        (hostname=None), so _is_azure_endpoint_ re-parses it network-relative
+        rather than silently classifying it as non-Azure. Reaching the
+        api_version guard proves Azure routing happened."""
+        model_config = wrap_model_config(
+            {
+                "provider": "openai",
+                "model_name": "gpt-4",
+                "api_base": "my-resource.openai.azure.com/",
+            }
+        )
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            with self.assertRaisesRegex(LCELModelException, "api_version is required"):
+                _get_direct_model_(model_config)
+
+    @patch("connectchain.lcel.model.logger")
+    @patch("langchain.chat_models.init_chat_model")
+    def test_api_key_env_unset_warns_and_falls_back_to_default_env_on_fast_path(
+        self, mock_init_chat_model, mock_logger
+    ):
+        """CODE-REVIEW regression: a config naming api_key_env whose env var is unset
+        must NOT fail hard on the init_chat_model fast path -- the baseline silently
+        omitted api_key and let init_chat_model resolve the provider's default env var
+        (e.g. OPENAI_API_KEY), which can work. The misconfiguration is surfaced via a
+        logger.warning naming the unset variable, then init proceeds WITHOUT an
+        explicit api_key so the provider-default resolution applies."""
+        model_config = wrap_model_config(
+            {
+                "provider": "openai",
+                "model_name": "gpt-4",
+                "api_key_env": "MY_CUSTOM_KEY_VAR_THAT_IS_UNSET",
+            }
+        )
+        env = {k: v for k, v in os.environ.items() if k != "MY_CUSTOM_KEY_VAR_THAT_IS_UNSET"}
+        with patch.dict(os.environ, env, clear=True):
+            result = _get_direct_model_(model_config)
+        self.assertIs(result, mock_init_chat_model.return_value)
+        self.assertNotIn("api_key", mock_init_chat_model.call_args.kwargs)
+        mock_logger.warning.assert_called_once()
+        self.assertTrue(
+            any(
+                "MY_CUSTOM_KEY_VAR_THAT_IS_UNSET" in str(arg)
+                for arg in mock_logger.warning.call_args[0]
+            ),
+            "warning must name the unset env var",
+        )
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_temperature_forwarded_on_fast_path(self, mock_init_chat_model):
+        """Companion to the manual-fallback temperature tests: the init_chat_model()
+        fast path builds its temperature kwarg through the shared
+        _temperature_kwargs_() helper (it used to hand-roll the same logic), so a
+        configured temperature must be forwarded..."""
+        model_config = wrap_model_config(
+            {"provider": "openai", "model_name": "gpt-4", "temperature": 0.25}
+        )
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            _get_direct_model_(model_config)
+        self.assertEqual(mock_init_chat_model.call_args.kwargs["temperature"], 0.25)
+
+    @patch("langchain.chat_models.init_chat_model")
+    def test_unset_temperature_not_forced_on_fast_path(self, mock_init_chat_model):
+        """...and an unset temperature must be omitted entirely (each provider keeps
+        its own default) rather than forced to None."""
+        model_config = wrap_model_config({"provider": "openai", "model_name": "gpt-4"})
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            _get_direct_model_(model_config)
+        self.assertNotIn("temperature", mock_init_chat_model.call_args.kwargs)
+
+    def test_temperature_honored_on_manual_fallback_path(self):
+        """CODE-REVIEW regression: configured temperature was only honored on the
+        init_chat_model fast path; the manual fallback ChatOpenAI dropped it."""
+        model_config = wrap_model_config(
+            {
+                "provider": "openai",
+                # Non-inferable name forces the manual fallback branch.
+                "model_name": "test_model",
+                "temperature": 0.25,
+            }
+        )
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            result = _get_direct_model_(model_config)
+        self.assertIsInstance(result, ChatOpenAI)
+        self.assertEqual(result.temperature, 0.25)
+
+    def test_temperature_honored_on_huggingface_fallback(self):
+        """CODE-REVIEW regression: the configured-temperature fix
+        (**_temperature_kwargs_()) was applied to the other provider constructors but
+        the huggingface branch (HuggingFaceEndpoint) was missed, silently dropping a
+        configured temperature. langchain_huggingface may not be installed in the
+        test environment, so the import is satisfied via a sys.modules mock."""
+        import sys  # pylint: disable=import-outside-toplevel
+
+        mock_endpoint_cls = Mock(name="HuggingFaceEndpoint")
+        mock_module = Mock(HuggingFaceEndpoint=mock_endpoint_cls)
+        model_config = wrap_model_config(
+            {
+                "provider": "huggingface",
+                # Non-inferable name forces the manual fallback branch.
+                "model_name": "test-org/test-repo",
+                "temperature": 0.25,
+            }
+        )
+        with patch.dict(sys.modules, {"langchain_huggingface": mock_module}):
+            with patch.dict(os.environ, {"HUGGINGFACE_API_KEY": "hf-test-key"}):
+                result = _get_direct_model_(model_config)
+        self.assertIs(result, mock_endpoint_cls.return_value)
+        self.assertEqual(mock_endpoint_cls.call_args.kwargs["temperature"], 0.25)
+
+    def test_unset_temperature_not_forced_on_huggingface_fallback(self):
+        """Companion to the above: when no temperature is configured, the huggingface
+        branch must not pass temperature at all (each provider keeps its own default,
+        per _temperature_kwargs_) rather than forcing temperature=None."""
+        import sys  # pylint: disable=import-outside-toplevel
+
+        mock_endpoint_cls = Mock(name="HuggingFaceEndpoint")
+        mock_module = Mock(HuggingFaceEndpoint=mock_endpoint_cls)
+        model_config = wrap_model_config(
+            {"provider": "huggingface", "model_name": "test-org/test-repo"}
+        )
+        with patch.dict(sys.modules, {"langchain_huggingface": mock_module}):
+            with patch.dict(os.environ, {"HUGGINGFACE_API_KEY": "hf-test-key"}):
+                _get_direct_model_(model_config)
+        self.assertNotIn("temperature", mock_endpoint_cls.call_args.kwargs)
+
+    def test_unquoted_yaml_date_api_version_is_coerced_to_string(self):
+        """VERIFY finding: YAML parses an unquoted `api_version: 2024-02-01` as a
+        datetime.date, which AzureOpenAI's pydantic validation rejects opaquely.
+        The api_version guard must coerce it so the natural config spelling works."""
+        import datetime  # pylint: disable=import-outside-toplevel
+
+        model_config = wrap_model_config(
+            {
+                "provider": "openai",
+                "model_name": "gpt-4",
+                "api_base": "https://my-resource.openai.azure.com/",
+                "api_version": datetime.date(2024, 2, 1),  # what yaml.safe_load produces
+                "engine": "gpt-4",
+            }
+        )
+        with patch.dict(os.environ, {"OPENAI_API_KEY": "test-key"}):
+            result = _get_direct_model_(model_config)
+        self.assertIsInstance(result, AzureOpenAI)
+
+    @patch("connectchain.lcel.model.ChatOpenAI", return_value=Mock(ChatOpenAI))
+    # pylint: disable=unused-argument
+    def test_model_eas_chat_missing_api_version_raises_clear_error(self, *args):
+        """Regression test: the EAS/_get_chat_model_ path must raise a clear
+        LCELModelException for a missing api_version instead of an opaque pydantic
+        ValidationError from deep inside ChatOpenAI's constructor."""
+        test_config = get_mock_config()
+        test_config.data["models"]["1"] = {**test_config.data["models"]["1"]}
+        del test_config.data["models"]["1"]["api_version"]
+        self.setUpWithConfig(test_config)
+        with self.assertRaisesRegex(LCELModelException, "api_version is required") as _:
+            test_model = model()
+
+    @patch("connectchain.lcel.model.AzureOpenAI", return_value=Mock(AzureOpenAI))
+    # pylint: disable=unused-argument
+    def test_model_eas_azure_missing_api_version_raises_clear_error(self, *args):
+        """Regression test: the EAS/_get_azure_model_ path must raise a clear
+        LCELModelException for a missing api_version instead of an opaque pydantic
+        ValidationError from deep inside AzureOpenAI's constructor."""
+        test_config = get_mock_config()
+        test_config.data["models"]["2"] = {**test_config.data["models"]["2"]}
+        del test_config.data["models"]["2"]["api_version"]
+        self.setUpWithConfig(test_config)
+        with self.assertRaisesRegex(LCELModelException, "api_version is required") as _:
+            test_model = model("2")
 
     @patch("connectchain.lcel.model.wrap_llm_with_proxy")
     def test_model_configured_with_no_proxy(self, mock_wrap_with_proxy):

--- a/tests/unit_tests/test_proxy_wrapper.py
+++ b/tests/unit_tests/test_proxy_wrapper.py
@@ -10,11 +10,14 @@
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
 """Unit testing for llm proxy wrapping utilities"""
+
 import asyncio
 import unittest
 from unittest.mock import Mock, patch
 
-from .setup_utils import get_mock_ctx_manager
+from langchain_core.language_models import BaseChatModel, BaseLanguageModel
+from langchain_openai import ChatOpenAI
+
 from connectchain.utils.llm_proxy_wrapper import (
     _async_proxy_,
     _llm_async_methods_,
@@ -24,6 +27,8 @@ from connectchain.utils.llm_proxy_wrapper import (
     wrap_llm_with_proxy,
 )
 from connectchain.utils.proxy_manager import ProxyManager
+
+from .setup_utils import get_mock_ctx_manager
 
 
 class MockLLM:
@@ -103,3 +108,16 @@ class TestProxyWrapping(unittest.TestCase):
                 self.assertIs(decorator, _async_proxy_)
             else:
                 self.fail(f"Unexpected method name {method_name}")
+
+    def test_wrapping_accepts_base_chat_model(self):
+        """BUG-5 regression: every real ConnectChain target (ChatOpenAI, etc.) is a
+        BaseChatModel, which shares only BaseLanguageModel with BaseLLM — not BaseLLM
+        itself. Before the fix the type hint claimed BaseLLM, which BaseChatModel
+        instances are not, mis-describing the actual accepted type. This confirms a
+        real BaseChatModel wraps successfully and satisfies the corrected annotation."""
+        chat_model = ChatOpenAI(model="gpt-3.5-turbo", openai_api_key="test-key")
+        self.assertIsInstance(chat_model, BaseChatModel)
+        self.assertIsInstance(chat_model, BaseLanguageModel)
+        # Should not raise: wrap_llm_with_proxy's signature now accepts BaseLanguageModel
+        wrap_llm_with_proxy(chat_model, proxy_config=None)
+        self.assertTrue(hasattr(chat_model, "invoke"))

--- a/tests/unit_tests/test_retry_utils.py
+++ b/tests/unit_tests/test_retry_utils.py
@@ -14,7 +14,18 @@ import asyncio
 from unittest import TestCase
 from unittest.mock import AsyncMock, Mock, call, patch
 
+from connectchain.utils.exceptions import NonRetryableError
 from connectchain.utils.retry import abase_retry, aretry_decorator, base_retry, retry_decorator
+
+
+class _PermanentError(Exception, NonRetryableError):
+    """Stand-in for LCELModelException/ConfigException in these generic retry tests."""
+
+
+class _UnrelatedPermanentError(Exception, NonRetryableError):
+    """A second, unrelated NonRetryableError-marked family. Used to prove the
+    explicit opt-in is per-family: opting THIS family into retries must not
+    disable fail-fast for _PermanentError (and vice versa)."""
 
 
 def get_named_mock(*args, use_async=False, **kwargs) -> Mock:
@@ -85,6 +96,74 @@ class TestRetryUtils(TestCase):
             ]
         )
 
+    @patch("connectchain.utils.retry.sleep")
+    def test_base_retry_does_not_retry_nonretryable_error(self, mock_sleep: Mock) -> None:
+        """Regression test: an exception matching the default `exceptions=Exception`
+        filter but marked NonRetryableError (e.g. LCELModelException for a missing
+        API key) must fail on the first attempt, not be retried max_retry times."""
+        mock_func = get_named_mock(side_effect=_PermanentError("permanent config error"))
+        with self.assertRaises(_PermanentError):
+            base_retry(mock_func, max_retry=3, log_func=Mock())
+        self.assertEqual(mock_func.call_count, 1)
+        mock_sleep.assert_not_called()
+
+    @patch("connectchain.utils.retry.sleep")
+    def test_base_retry_explicit_optin_overrides_nonretryable_marker(
+        self, mock_sleep: Mock
+    ) -> None:
+        """CODE-REVIEW regression: a caller who EXPLICITLY lists a
+        NonRetryableError-marked type in `exceptions` has asked to retry that
+        family; the marker's fail-fast must not silently override that explicit
+        request (it only applies under the generic default filter)."""
+        mock_func = get_named_mock(side_effect=_PermanentError("flagged but opted in"))
+        with self.assertRaises(_PermanentError):
+            base_retry(mock_func, max_retry=3, exceptions=_PermanentError, log_func=Mock())
+        self.assertEqual(mock_func.call_count, 3)
+
+    @patch("connectchain.utils.retry.sleep")
+    def test_base_retry_nonretryable_optin_is_per_family(self, mock_sleep: Mock) -> None:
+        """CODE-REVIEW regression: the explicit opt-in must be PER-FAMILY.
+        `exceptions=(_UnrelatedPermanentError, Exception)` opts only
+        _UnrelatedPermanentError into retries; a _PermanentError caught via the
+        broad `Exception` entry is NOT covered by that opt-in and must still
+        fail fast on the first attempt."""
+        mock_func = get_named_mock(side_effect=_PermanentError("not the opted-in family"))
+        with self.assertRaises(_PermanentError):
+            base_retry(
+                mock_func,
+                max_retry=3,
+                exceptions=(_UnrelatedPermanentError, Exception),
+                log_func=Mock(),
+            )
+        self.assertEqual(mock_func.call_count, 1)
+        mock_sleep.assert_not_called()
+
+        # The family that WAS explicitly listed is retried, even alongside the
+        # broad Exception entry -- the opt-in applies to it and only it.
+        mock_func = get_named_mock(side_effect=_UnrelatedPermanentError("opted-in family"))
+        with self.assertRaises(_UnrelatedPermanentError):
+            base_retry(
+                mock_func,
+                max_retry=3,
+                exceptions=(_UnrelatedPermanentError, Exception),
+                log_func=Mock(),
+            )
+        self.assertEqual(mock_func.call_count, 3)
+
+        # And an UNMARKED exception caught via the broad entry keeps normal
+        # retry behavior -- fail-fast only ever applies to marked families.
+        mock_func = get_named_mock(side_effect=[ValueError("transient"), 42])
+        self.assertEqual(
+            base_retry(
+                mock_func,
+                max_retry=3,
+                exceptions=(_UnrelatedPermanentError, Exception),
+                log_func=Mock(),
+            ),
+            42,
+        )
+        self.assertEqual(mock_func.call_count, 2)
+
     @patch("connectchain.utils.retry.asyncio.sleep")
     def test_abase_retry(self, mock_sleep: Mock) -> None:
         """Unit test for the abase_retry function."""
@@ -140,6 +219,60 @@ class TestRetryUtils(TestCase):
                 call("Function mock_func failed after 3 attempts."),
             ]
         )
+
+    @patch("connectchain.utils.retry.asyncio.sleep")
+    def test_abase_retry_does_not_retry_nonretryable_error(self, mock_sleep: Mock) -> None:
+        """Async counterpart of test_base_retry_does_not_retry_nonretryable_error."""
+        mock_func = get_named_mock(use_async=True, side_effect=_PermanentError("permanent"))
+        with self.assertRaises(_PermanentError):
+            asyncio.run(abase_retry(mock_func, max_retry=3, log_func=Mock()))
+        self.assertEqual(mock_func.call_count, 1)
+        mock_sleep.assert_not_called()
+
+    @patch("connectchain.utils.retry.asyncio.sleep")
+    def test_abase_retry_explicit_optin_overrides_nonretryable_marker(
+        self, mock_sleep: Mock
+    ) -> None:
+        """Async counterpart of test_base_retry_explicit_optin_overrides_nonretryable_marker."""
+        mock_func = get_named_mock(use_async=True, side_effect=_PermanentError("opted in"))
+        with self.assertRaises(_PermanentError):
+            asyncio.run(
+                abase_retry(mock_func, max_retry=3, exceptions=_PermanentError, log_func=Mock())
+            )
+        self.assertEqual(mock_func.call_count, 3)
+
+    @patch("connectchain.utils.retry.asyncio.sleep")
+    def test_abase_retry_nonretryable_optin_is_per_family(self, mock_sleep: Mock) -> None:
+        """Async counterpart of test_base_retry_nonretryable_optin_is_per_family."""
+        mock_func = get_named_mock(
+            use_async=True, side_effect=_PermanentError("not the opted-in family")
+        )
+        with self.assertRaises(_PermanentError):
+            asyncio.run(
+                abase_retry(
+                    mock_func,
+                    max_retry=3,
+                    exceptions=(_UnrelatedPermanentError, Exception),
+                    log_func=Mock(),
+                )
+            )
+        self.assertEqual(mock_func.call_count, 1)
+        mock_sleep.assert_not_called()
+
+    def test_util_exception_is_nonretryable(self) -> None:
+        """CODE-REVIEW regression: UtilException raises for permanent config errors
+        (missing models, unset env keys) and must carry the NonRetryableError marker
+        like its siblings (LCELModelException, ConfigException) -- otherwise a
+        retry-wrapped get_token_from_env() burns max_retry attempts on an error
+        that can never succeed."""
+        from connectchain.utils.token_util import UtilException  # pylint: disable=import-outside-toplevel
+
+        self.assertTrue(issubclass(UtilException, NonRetryableError))
+        self.assertTrue(issubclass(UtilException, Exception))
+        mock_func = get_named_mock(side_effect=UtilException("No models defined in config"))
+        with self.assertRaises(UtilException):
+            base_retry(mock_func, max_retry=3, sleep_time=0, log_func=Mock())
+        self.assertEqual(mock_func.call_count, 1)
 
     def test_retry_decorator(self) -> None:
         """Unit test for the retry_decorator function."""

--- a/tests/unit_tests/test_session_map.py
+++ b/tests/unit_tests/test_session_map.py
@@ -9,8 +9,11 @@
 # is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
 # or implied. See the License for the specific language governing permissions and limitations under
 # the License.
-"""Unit testing for SessionMap class"""
+"""Unit testing for SessionMap class — BUG-2 regression suite"""
+import threading
 import unittest
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock
 
 from .setup_utils import get_mock_config, wrap_model_config
 from connectchain.utils import SessionMap
@@ -19,8 +22,15 @@ from connectchain.utils import SessionMap
 class TestSessionMap(unittest.TestCase):
     """Unit testing the SessionMap"""
 
+    def setUp(self):
+        """Reset the singleton and its shared cache so tests don't leak state."""
+        SessionMap._instance = None  # pylint: disable=protected-access
+        SessionMap.session_map.clear()
+
+    # ── Existing tests (unchanged) ──────────────────────────────────────────
+
     def test_uuid_from_config(self):
-        """Test that a PortableOrchestrator instance can be built with the default LLM"""
+        """UUID generation from config produces stable, predictable strings."""
         test_config = get_mock_config()
         test_uuid = SessionMap.uuid_from_config(test_config, test_config.models["1"])
         test_uuid2 = SessionMap.uuid_from_config(test_config, test_config.models["2"])
@@ -30,6 +40,7 @@ class TestSessionMap(unittest.TestCase):
         )
 
     def test_model_config_override(self):
+        """Per-model EAS config overrides the global config values."""
         test_config = get_mock_config()
         test_model_config = wrap_model_config(
             {
@@ -45,3 +56,262 @@ class TestSessionMap(unittest.TestCase):
         self.assertEqual(
             test_uuid, "mod_id_mod_sec_oss_provider_some_model_type_oss_engine_some_model_latest"
         )
+
+    def test_uuid_from_config_partial_model_eas_falls_back_per_key(self):
+        """A per-model eas section that overrides only SOME keys must fall back to
+        the global section for the rest, and missing optional model fields must
+        keep rendering as the literal "None" placeholder: uuid_from_config is a
+        cache-key builder, not a validator, so it must not start raising now that
+        ConfigWrapper is strict about missing attributes."""
+        test_config = get_mock_config()
+        test_model_config = wrap_model_config(
+            {
+                "eas": {"id_key": "mod_id"},  # no secret_key -> global fallback
+                "provider": "openai",
+                "type": "chat",
+                "model_name": "m",
+                # no engine / api_version -> "None" placeholders in the key
+            }
+        )
+        test_uuid = SessionMap.uuid_from_config(test_config, test_model_config)
+        self.assertEqual(test_uuid, "mod_id_secret_key_openai_chat_None_m_None")
+
+    # ── BUG-2 FIX: regression tests ─────────────────────────────────────────
+
+    def test_is_expired_unknown_session_returns_true(self):
+        """BUG-2: is_expired() must return True (not raise KeyError) for unknown session IDs."""
+        sm = SessionMap(expires_in=900)
+        # Must not raise KeyError; must return True to trigger token refresh
+        result = sm.is_expired("session-that-was-never-registered")
+        self.assertTrue(result)
+
+    def test_is_expired_active_session_returns_false(self):
+        """A freshly created session must not be considered expired."""
+        sm = SessionMap(expires_in=900)
+        mock_llm = MagicMock()
+        sm.new_session("active-session", mock_llm)
+        self.assertFalse(sm.is_expired("active-session"))
+
+    def test_is_expired_stale_session_returns_true(self):
+        """A session whose timestamp is older than its expires_in must be expired."""
+        sm = SessionMap(expires_in=900)
+        mock_llm = MagicMock()
+        sm.new_session("stale-session", mock_llm)
+        # Backdate the timestamp (entries are (cached_at, expires_in, llm) tuples)
+        sm.session_map["stale-session"] = (
+            datetime.now() - timedelta(seconds=1000),
+            900,
+            mock_llm,
+        )
+        self.assertTrue(sm.is_expired("stale-session"))
+
+    def test_thread_safety_no_race_condition(self):
+        """A writer racing readers on the SAME session_id must never raise or
+        expose a partially-published entry.
+
+        The old version of this test only ever called is_expired() on a key
+        that was never registered via new_session() -- so there were no
+        concurrent writes and nothing was actually contended (it passed even
+        with self._lock removed entirely). This drives the real scenario the
+        lock protects: new_session() (writer) racing is_expired()/
+        get_valid_llm()/get_llm() (readers) on one shared key.
+
+        Note: on GIL CPython, single dict store/get operations are atomic, so
+        this test may still pass with the lock removed; its teeth are as a
+        contract/regression test if these methods ever become compound
+        (multi-step) mutations, and on free-threaded (no-GIL) builds.
+        """
+        sm = SessionMap(expires_in=900)
+        key = "concurrent-key"
+        mock_llm = MagicMock()
+        errors: list = []
+        stop = threading.Event()
+
+        def writer():
+            for _ in range(1000):
+                if stop.is_set():
+                    return
+                try:
+                    sm.new_session(key, mock_llm)
+                except Exception as exc:  # pylint: disable=broad-except
+                    errors.append(exc)
+                    stop.set()
+                    return
+
+        def reader():
+            for _ in range(1000):
+                if stop.is_set():
+                    return
+                try:
+                    sm.is_expired(key)
+                    sm.get_valid_llm(key)
+                    if not sm.is_expired(key):
+                        # Documented precondition: safe once is_expired() said fresh.
+                        sm.get_llm(key)
+                except Exception as exc:  # pylint: disable=broad-except
+                    errors.append(exc)
+                    stop.set()
+                    return
+
+        threads = [threading.Thread(target=writer) for _ in range(4)]
+        threads += [threading.Thread(target=reader) for _ in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(errors, [], f"Race condition detected: {errors}")
+        entry = sm.session_map[key]
+        self.assertIsInstance(entry, tuple)
+        self.assertEqual(len(entry), 3)
+        cached_at, expires_in, llm = entry
+        self.assertIsInstance(cached_at, datetime)
+        self.assertEqual(expires_in, 900)
+        self.assertIs(llm, mock_llm)
+        self.assertFalse(sm.is_expired(key))
+        self.assertIs(sm.get_valid_llm(key), mock_llm)
+
+    def test_concurrent_first_construction_yields_single_consistent_instance(self):
+        """CODE-REVIEW FOLLOWUP regression: __new__'s singleton construction was
+        an unguarded check-then-act race -- many threads calling SessionMap(...)
+        for the very first time simultaneously could each construct their own
+        instance/lock and race to assign cls._instance, potentially returning
+        different instances (or an instance whose expires_in came from a
+        different thread's call) to different callers. All threads here race
+        to construct the singleton for the first time with distinct expires_in
+        values; every caller must get back the exact same instance."""
+        results: list = []
+        errors: list = []
+
+        def worker(expires_in: int) -> None:
+            try:
+                results.append(SessionMap(expires_in=expires_in))
+            except Exception as exc:  # pylint: disable=broad-except
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=worker, args=(i,)) for i in range(100, 100 + 20)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        self.assertEqual(errors, [], f"Errors during construction: {errors}")
+        self.assertEqual(len(results), 20)
+        self.assertTrue(
+            all(instance is results[0] for instance in results),
+            "Concurrent first construction returned more than one distinct instance",
+        )
+
+    # ── Per-session expiry regression tests ─────────────────────────────────
+
+    def test_expires_in_is_captured_per_session_not_shared(self):
+        """A session cached under one expires_in must keep its own expiry even after
+        the singleton is later reconstructed with a different interval for another model"""
+        session_map = SessionMap(900)
+        session_map.new_session("long-lived", "llm-1")
+        # Simulate 5 seconds having elapsed since the session was cached.
+        cached_at, expires_in, llm = session_map.session_map["long-lived"]
+        session_map.session_map["long-lived"] = (cached_at - timedelta(seconds=5), expires_in, llm)
+
+        # A later caller resolves a different model configured with a much shorter interval.
+        reconfigured = SessionMap(1)
+        self.assertIs(session_map, reconfigured)
+
+        # The long-lived session was cached under expires_in=900 and must still honor
+        # that, not the most-recently-configured value of 1.
+        self.assertFalse(reconfigured.is_expired("long-lived"))
+
+        # A session cached after the reconfiguration correctly uses the new interval.
+        reconfigured.new_session("short-lived", "llm-2")
+        cached_at, expires_in, llm = reconfigured.session_map["short-lived"]
+        reconfigured.session_map["short-lived"] = (
+            cached_at - timedelta(seconds=5),
+            expires_in,
+            llm,
+        )
+        self.assertTrue(reconfigured.is_expired("short-lived"))
+
+    def test_new_session_uses_explicit_expires_in_not_singleton_value_at_write_time(self):
+        """Regression test for a write-time race: a caller must be able to capture
+        expires_in immediately (e.g. before a slow network call) and have new_session()
+        honor that captured value, even if another caller reconfigures the singleton's
+        shared `expires_in` field in between -- reading self.expires_in only inside
+        new_session() would silently apply the wrong, most-recently-configured interval
+        instead of the one this session was actually meant to use."""
+        session_map = SessionMap(900)
+        captured_expires_in = session_map.expires_in  # captured "before the network call"
+
+        # Another request reconfigures the singleton for a different model in between.
+        SessionMap(1)
+
+        # Passing the captured value explicitly must win over the singleton's current value.
+        session_map.new_session("my-session", "llm-1", captured_expires_in)
+        self.assertEqual(session_map.session_map["my-session"][1], 900)
+
+    def test_bare_construction_does_not_reset_configured_interval(self):
+        """CODE-REVIEW regression: SessionMap() with no argument (e.g. constructed just
+        to read the cache) must NOT silently reset a previously configured interval
+        back to the default."""
+        SessionMap(3600)
+        sm = SessionMap()  # bare read-only construction
+        self.assertEqual(sm.expires_in, 3600)
+        sm.new_session("k", "llm")
+        self.assertEqual(sm.session_map["k"][1], 3600)
+        # An explicit reconfiguration still works.
+        SessionMap(60)
+        self.assertEqual(sm.expires_in, 60)
+
+    def test_reconfigure_with_unchanged_value_skips_locked_write(self):
+        """CODE-REVIEW regression: SessionMap(value) is constructed on the model()
+        hot path, and value almost always equals the already-configured default.
+        Unconditionally taking self._lock -- shared with every session_map cache
+        read/write -- just to rewrite an identical int was pure lock contention,
+        so an unchanged value must skip the locked write entirely. An actual
+        change must still take the lock (the write may not interleave with
+        new_session()'s locked fallback read), and a bare SessionMap() still
+        never reconfigures."""
+        sm = SessionMap(900)
+
+        class CountingLock:
+            """Context-manager lock wrapper that counts acquisitions."""
+
+            def __init__(self):
+                self.acquisitions = 0
+                self._inner = threading.Lock()
+
+            def __enter__(self):
+                self.acquisitions += 1
+                self._inner.acquire()
+                return self
+
+            def __exit__(self, *args):
+                self._inner.release()
+                return False
+
+        counting_lock = CountingLock()
+        sm._lock = counting_lock  # pylint: disable=protected-access
+
+        SessionMap(900)  # unchanged value: no locked write
+        self.assertEqual(counting_lock.acquisitions, 0)
+        self.assertEqual(sm.expires_in, 900)
+
+        SessionMap()  # bare construction: "don't reconfigure", never locks
+        self.assertEqual(counting_lock.acquisitions, 0)
+        self.assertEqual(sm.expires_in, 900)
+
+        SessionMap(60)  # actual reconfiguration: locked write, value updated
+        self.assertEqual(counting_lock.acquisitions, 1)
+        self.assertEqual(sm.expires_in, 60)
+
+    def test_missing_token_refresh_interval_uses_default_not_none(self):
+        """CODE-REVIEW regression: a config without eas.token_refresh_interval reaches
+        SessionMap as None (the model() path resolves the missing key to None via
+        getattr's default). That must
+        fall back to the default -- previously the entry cached expires_in=None and
+        every later cache-hit expiry check crashed with TypeError ('>' vs NoneType)."""
+        sm = SessionMap(None)
+        self.assertEqual(sm.expires_in, SessionMap.DEFAULT_EXPIRES_IN)
+        sm.new_session("k", "llm", None)
+        self.assertEqual(sm.session_map["k"][1], SessionMap.DEFAULT_EXPIRES_IN)
+        self.assertFalse(sm.is_expired("k"))  # must not raise TypeError

--- a/tests/unit_tests/test_token_util_retryability.py
+++ b/tests/unit_tests/test_token_util_retryability.py
@@ -1,0 +1,106 @@
+# Copyright 2025 American Express Travel Related Services Company, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License. You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under the License
+# is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+# or implied. See the License for the specific language governing permissions and limitations under
+# the License.
+"""Retryability contract tests for token_util exceptions.
+
+UtilException carries the NonRetryableError marker because it is raised for
+permanent config errors (missing models, undefined index, unset env keys,
+expired cert) that can never succeed on retry. But a non-200 response from the
+EAS auth service may be transient (5xx, throttling), so it must surface as the
+plain, retry-eligible EASAuthError instead -- otherwise a retry-wrapped token
+fetch fails fast on a recoverable server error. These tests pin down that
+split. The EAS HTTP layer is mocked throughout; no network calls are made."""
+import asyncio
+from unittest import TestCase
+from unittest.mock import Mock, patch
+
+from .setup_utils import get_mock_config
+from connectchain.utils import TokenUtil, UtilException
+from connectchain.utils.exceptions import NonRetryableError
+from connectchain.utils.retry import base_retry
+from connectchain.utils.token_util import EASAuthError
+
+
+class TestTokenUtilRetryability(TestCase):
+    """Unit test class proving EAS auth failures are retried while permanent
+    config errors still fail fast."""
+
+    def test_eas_auth_error_is_retry_eligible(self) -> None:
+        """EASAuthError must be a plain Exception: neither NonRetryableError-marked
+        nor a UtilException subclass (which would inherit the marker)."""
+        self.assertTrue(issubclass(EASAuthError, Exception))
+        self.assertFalse(issubclass(EASAuthError, NonRetryableError))
+        self.assertFalse(issubclass(EASAuthError, UtilException))
+
+    @patch("connectchain.utils.retry.sleep")
+    @patch("os.path.exists", return_value=True)
+    def test_non_200_response_is_retried_by_base_retry(self, _mock_exists, mock_sleep) -> None:
+        """CODE-REVIEW regression: a transient 5xx from the EAS auth service must
+        be retryable. A retry-wrapped token fetch that gets a 503 and then a 200
+        should succeed on the second attempt instead of failing fast."""
+        # Secret must be valid base64 -- __get_signature b64-decodes it for the HMAC key.
+        token_util = TokenUtil("test_id", "dGVzdF9zZWNyZXQ=", get_mock_config())
+        responses = [
+            ({"description": "Service Unavailable"}, 503),
+            ({"authorization_token": "test_token"}, 200),
+        ]
+        with patch.object(
+            TokenUtil, "_TokenUtil__aio_http_post", side_effect=responses
+        ) as mock_post:
+
+            def fetch_token() -> str:
+                return asyncio.run(token_util.get_token(token_util.config.models["1"]))
+
+            token = base_retry(fetch_token, max_retry=3, log_func=Mock())
+        self.assertEqual(token, "Bearer test_token")
+        self.assertEqual(mock_post.call_count, 2)
+        mock_sleep.assert_called_once_with(1)
+
+    @patch("connectchain.utils.retry.sleep")
+    @patch("os.path.exists", return_value=True)
+    def test_non_200_response_raises_eas_auth_error(self, _mock_exists, _mock_sleep) -> None:
+        """A persistent non-200 surfaces as EASAuthError (not UtilException) after
+        the retries are exhausted, carrying the service's error description."""
+        token_util = TokenUtil("test_id", "dGVzdF9zZWNyZXQ=", get_mock_config())
+        with patch.object(
+            TokenUtil,
+            "_TokenUtil__aio_http_post",
+            return_value=({"description": "Internal Server Error"}, 500),
+        ) as mock_post:
+
+            def fetch_token() -> str:
+                return asyncio.run(token_util.get_token(token_util.config.models["1"]))
+
+            with self.assertRaisesRegex(EASAuthError, "Internal Server Error"):
+                base_retry(fetch_token, max_retry=3, log_func=Mock())
+        # All attempts were used -- proof the error did NOT fail fast.
+        self.assertEqual(mock_post.call_count, 3)
+
+    @patch("connectchain.utils.retry.sleep")
+    @patch(
+        "connectchain.utils.token_util.Config.from_env",
+        return_value=get_mock_config({}),
+    )
+    def test_missing_models_config_error_still_fails_fast(
+        self, _mock_config, mock_sleep
+    ) -> None:
+        """Contrast case: the permanent no-models config error keeps the
+        NonRetryableError marker, so a retry-wrapped get_token_from_env() fails
+        on the first attempt instead of burning max_retry attempts."""
+        # pylint: disable-next=import-outside-toplevel
+        from connectchain.utils import get_token_from_env
+
+        mock_func = Mock(wraps=get_token_from_env)
+        mock_func.__name__ = "get_token_from_env"
+        with self.assertRaisesRegex(UtilException, "No models defined in config"):
+            base_retry(mock_func, args=("other",), max_retry=3, log_func=Mock())
+        self.assertEqual(mock_func.call_count, 1)
+        mock_sleep.assert_not_called()

--- a/tests/unit_tests/utils/test_config_mcp.py
+++ b/tests/unit_tests/utils/test_config_mcp.py
@@ -55,16 +55,22 @@ class TestConfigMCP:
         assert servers.data["web_tools"]["transport"] == "streamable-http"
 
     def test_get_mcp_servers_without_servers(self, config_without_mcp):
-        """Test getting MCP servers when none exist."""
-        try:
-            servers = config_without_mcp.mcp.servers
-            assert False, "Should have raised KeyError"
-        except KeyError:
-            # Expected behavior when mcp section doesn't exist
-            pass
+        """Test getting MCP servers when the mcp section doesn't exist.
+
+        Config raises AttributeError for a missing top-level key (formerly
+        KeyError, which escaped through hasattr()/getattr(default)), so the
+        idiomatic optional-access tools work on the root config object."""
+        with pytest.raises(AttributeError, match="mcp"):
+            _ = config_without_mcp.mcp.servers
+        assert getattr(config_without_mcp, "mcp", None) is None
 
     def test_get_mcp_servers_partial_config(self):
-        """Test getting MCP servers with partial config."""
+        """Test getting MCP servers with a partial config (mcp section present
+        but no servers key).
+
+        ConfigWrapper is strict now: a missing key raises AttributeError
+        instead of silently returning None, so callers that treat servers as
+        optional must (and can) use getattr's default."""
         config_data = {
             "mcp": {
                 # No servers key
@@ -75,5 +81,6 @@ class TestConfigMCP:
             yaml.dump(config_data, f)
             config = Config(f.name)
 
-        servers = config.mcp.servers
-        assert servers is None
+        with pytest.raises(AttributeError, match="servers"):
+            _ = config.mcp.servers
+        assert getattr(config.mcp, "servers", None) is None


### PR DESCRIPTION
## ⚠️ Contains a deliberate accessor-contract change — please read first

This PR consolidates the model-initialization, session-cache, and retry-semantics fixes, **and changes the config accessor contract**, because the two are one atomic change set (verified empirically — see "Why config.py is in this PR" below):

- Root `Config.__getattr__` missing-key behavior: `KeyError` → **`AttributeError`**
- Nested `ConfigWrapper.__getattr__` missing-key behavior: **silent `None`** → **`AttributeError`** (**breaking** for downstream callers relying on the `None` return; item access `cfg["key"]` stays lenient)

The old silent-`None` made `hasattr()` always-True and `getattr(x, k, default)` never return its default — hiding config typos and forcing per-call-site workarounds throughout the codebase, which this PR removes.

## Fixes

- **Silent exception swallowing in `_get_direct_model_`**: a bare `except: pass` permanently discarded all model-init errors (wrong API key, missing provider package, network failure). Now: expected fallback conditions (`ImportError`/`ValueError`) log and fall through to manual init; unexpected errors re-raise as `LCELModelConfigError` with the original traceback chained. Error-message construction itself can no longer raise (safe `getattr` for `model_name`).
- **Provider handling**: enumerated providers keep their manual init branches; non-enumerated providers are passed explicitly to `init_chat_model(model_name, model_provider=...)` so langchain-supported providers (mistral, groq, ollama, …) work, while genuinely unknown ones fail fast with a clear "not supported" error — and the check ordering no longer emits a misleading "falling back" warning or "API key not found" for a key that was never needed.
- **Azure routing**: Azure-shaped configs route to a dedicated builder *before* the generic fast path (which has no notion of `azure_endpoint`/`api_version`/`engine`); endpoint detection parses the hostname and suffix-matches Azure domains (blocks lookalike-host/path spoofing); `api_version` is validated with a clear error on both direct and EAS paths.
- **`SessionMap` thread safety and correctness**: `is_expired()` no longer raises `KeyError` for unregistered sessions; all reads/writes lock-guarded; singleton construction uses double-checked locking with full initialization before publication; `get_valid_llm()` does the existence+expiry check atomically; `expires_in` is captured per session (a later reconfiguration no longer retroactively changes cached sessions' expiry) and resolved before any network call.
- **Retry semantics**: `NonRetryableError` marker family — permanent config errors fail fast instead of burning `max_retry` attempts, strictly per-family so a broad filter can't re-enable retries for unrelated marked exceptions; transient EAS auth failures (non-200) raise the retry-eligible `EASAuthError` instead of a permanent error.
- **Typing**: `wrap_llm_with_proxy` accepts `BaseLanguageModel` (the real common ancestor of chat models) instead of the deprecated `langchain.llms.BaseLLM` import.

## Why config.py is in this PR

The coupling is bidirectional: the rewritten consumers rely on missing-key `AttributeError` (root `Config`'s old `KeyError` isn't swallowed by `getattr(default)`), and the new accessor breaks the old consumers' `except KeyError` paths. Splitting them produces two individually-red PRs; together the suite is fully green.

## Verification

- Full unit suite on this branch: **121 passed, 0 failed** — including the chains/orchestrator/MCP tests still at `main`'s state, confirming the accessor contract was the only cross-subsystem coupling.
- Fixes `main`'s own pre-existing test failure (`test_model_with_unsupported_provider`).
- pylint on touched files: 9.89/10 vs 8.24/10 baseline; mypy: no new real errors (3 new `import-not-found` are guarded optional provider packages).

## Sequencing

Includes the shared dependency pin (needed to build standalone); that hunk rebases away once #10 merges. Best reviewed/merged after the sanitizer/orchestrator PR.

Co-authored-by: Claude <noreply@anthropic.com>
