### PR TITLE
fix: MCP loader/agent — empty-list semantics, collision warning, kwargs forwarding, concurrent execution

### DIFF
--- a/connectchain/tools/mcp/agent.py
+++ b/connectchain/tools/mcp/agent.py
@@ -18,13 +18,15 @@ asynchronous invocation, error handling, and tool result aggregation."""
 
 import asyncio
 import logging
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
-from langchain.schema import AIMessage
 from langchain.schema.runnable import Runnable, RunnableConfig
 from langchain.tools import BaseTool
+from langchain_core.messages import BaseMessage
 
 from ...lcel import model
+
+logger = logging.getLogger(__name__)
 
 
 class MCPToolAgent(Runnable):  # pylint: disable=redefined-builtin
@@ -36,7 +38,15 @@ class MCPToolAgent(Runnable):  # pylint: disable=redefined-builtin
 
     def __init__(self, model_id: str, tools: List[BaseTool]):
         self.model_id = model_id
-        self.tools = {tool.name: tool for tool in tools}
+        self.tools: Dict[str, BaseTool] = {}
+        for tool in tools:
+            if tool.name in self.tools:
+                logger.warning(
+                    "Duplicate tool name '%s' from multiple servers; the later one "
+                    "overrides the earlier one.",
+                    tool.name,
+                )
+            self.tools[tool.name] = tool
 
     async def ainvoke(
         self,
@@ -49,32 +59,52 @@ class MCPToolAgent(Runnable):  # pylint: disable=redefined-builtin
         if hasattr(llm, "bind_tools"):
             llm = llm.bind_tools(list(self.tools.values()))
 
-        response = await llm.ainvoke(input, config)
+        # Forward **kwargs so caller-supplied run options (e.g. `stop`, provider-specific
+        # parameters) actually reach the underlying model instead of being silently dropped.
+        response = await llm.ainvoke(input, config, **kwargs)
+
+        # Extract the content once -- it's the same expression on every return path, and
+        # duplicating it at each return site invites the two copies drifting apart.
+        content = response.content if isinstance(response, BaseMessage) else str(response)
 
         if not hasattr(response, "tool_calls") or not response.tool_calls:
-            return response
+            # Match the declared `-> dict` contract on every path, not just when tools
+            # are requested -- otherwise callers can't uniformly do result["content"].
+            return {"content": content, "tool_results": []}
 
-        results = []
+        async def execute_tool(tool_name: str, tool_args: Any) -> dict:
+            """Run a single tool, mapping any failure to an error entry so one failing
+            tool never affects its siblings."""
+            try:
+                result = await self.tools[tool_name].ainvoke(tool_args)
+                return {"tool": tool_name, "result": result}
+            except Exception as e:  # pylint: disable=broad-except
+                logger.warning(
+                    "Tool '%s' execution failed: %s", tool_name, e
+                )
+                return {"tool": tool_name, "error": str(e)}
+
+        pending = []
         for tool_call in response.tool_calls:
             tool_name = tool_call.get("name") if isinstance(tool_call, dict) else tool_call.name
             tool_args = tool_call.get("args", {}) if isinstance(tool_call, dict) else tool_call.args
 
             if tool_name in self.tools:
-                try:
-                    result = await self.tools[tool_name].ainvoke(tool_args)
-                    results.append({"tool": tool_name, "result": result})
-                except Exception as e:  # pylint: disable=broad-except
-                    logging.getLogger(__name__).warning(
-                        "Tool '%s' execution failed: %s", tool_name, e
-                    )
-                    results.append({"tool": tool_name, "error": str(e)})
+                pending.append(execute_tool(tool_name, tool_args))
             else:
-                logging.getLogger(__name__).warning("Unknown tool requested: %s", tool_name)
+                # Unknown tools only produce a warning; they contribute no entry to
+                # tool_results (preserving the long-standing behavior).
+                logger.warning("Unknown tool requested: %s", tool_name)
 
-        return {
-            "content": response.content if isinstance(response, AIMessage) else str(response),
-            "tool_results": results,
-        }
+        # Run the requested tools concurrently rather than awaiting them one by one.
+        # gather() is safe here because the tool calls are independent of each other
+        # and MCP sessions handle concurrent calls; per-tool failures are already
+        # absorbed inside execute_tool, so one slow or failing tool cannot affect the
+        # rest. gather() also preserves ordering: results arrive in the same order as
+        # response.tool_calls (minus unknown tools), regardless of completion order.
+        results = list(await asyncio.gather(*pending))
+
+        return {"content": content, "tool_results": results}
 
     def invoke(
         self,

--- a/connectchain/tools/mcp/loader.py
+++ b/connectchain/tools/mcp/loader.py
@@ -40,8 +40,9 @@ class MCPToolLoader:
             )
             return []
 
-        # Filter servers if specific names requested
-        if server_names:
+        # Filter servers if specific names requested. `is not None` (not truthiness) so an
+        # explicit empty list means "connect to zero servers", not "no filter requested".
+        if server_names is not None:
             servers = {k: v for k, v in servers.items() if k in server_names}
 
         # Pass server configs directly to MultiServerMCPClient

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,13 +26,13 @@ dependencies = [
     "openai>=1.0.0",
     "pyyaml==6.0.1",
     "SQLAlchemy==2.0.22",
-    "langchain>=0.3.26",
-    "langchain-openai>=0.3.24",
-    "langchain-community>=0.3.26",
+    "langchain>=0.3.26,<0.4.0",
+    "langchain-openai>=0.3.24,<0.4.0",
+    "langchain-community>=0.3.26,<0.4.0",
     "tiktoken>=0.7.0",
     "python-dotenv~=1.0.0",
     "pyopenssl==23.3.0",
-    "langchain-mcp-adapters>=0.1.0",
+    "langchain-mcp-adapters>=0.1.0,<0.2.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/unit_tests/tools/test_mcp.py
+++ b/tests/unit_tests/tools/test_mcp.py
@@ -12,6 +12,7 @@
 
 """Tests for MCP tools."""
 
+import asyncio
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -57,7 +58,8 @@ class TestMCPToolAgent:
             agent = MCPToolAgent("1", mock_tools)
             result = await agent.ainvoke({"query": "What is 2+2?"})
 
-            assert result.content == "The answer is 42"
+            assert result["content"] == "The answer is 42"
+            assert result["tool_results"] == []
             assert mock_llm.bind_tools.called
 
     @pytest.mark.asyncio
@@ -126,6 +128,80 @@ class TestMCPToolAgent:
 
             assert result["tool_results"][0]["tool"] == "add"
             assert result["tool_results"][0]["error"] == "Tool failed"
+
+    @pytest.mark.asyncio
+    async def test_tool_calls_run_concurrently_in_order(self, mock_tools):
+        """Regression test: independent tool calls must run concurrently, and results
+        must stay in tool_calls order even when the first tool finishes last.
+
+        Previously each tool was awaited sequentially in a for loop, so a slow tool
+        blocked every tool after it. The rendezvous below is only satisfiable under
+        concurrent execution: 'add' (requested first) refuses to finish until
+        'multiply' (requested second) has started. Sequential execution would never
+        start 'multiply' while 'add' is pending, so 'add' would time out and surface
+        as an error entry instead of a result. asyncio.Event keeps this deterministic
+        -- no wall-clock sleeps or timing races."""
+        started = {"add": asyncio.Event(), "multiply": asyncio.Event()}
+
+        async def slow_add(_args):
+            started["add"].set()
+            # Completes only once 'multiply' has started -- proof both tools were
+            # in flight at the same time. The timeout is a safety net so a regression
+            # to sequential execution fails the assertions below instead of hanging.
+            await asyncio.wait_for(started["multiply"].wait(), timeout=2)
+            return 10
+
+        async def fast_multiply(_args):
+            started["multiply"].set()
+            return 20
+
+        mock_tools[0].ainvoke = AsyncMock(side_effect=slow_add)
+        mock_tools[1].ainvoke = AsyncMock(side_effect=fast_multiply)
+
+        with patch("connectchain.tools.mcp.agent.model") as mock_model:
+            mock_llm = AsyncMock()
+            mock_response = AIMessage(
+                content="I'll calculate that for you.",
+                tool_calls=[
+                    {"id": "1", "name": "add", "args": {"a": 5, "b": 5}},
+                    {"id": "2", "name": "multiply", "args": {"a": 2, "b": 10}},
+                ],
+            )
+            mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+            mock_llm.bind_tools = Mock(return_value=mock_llm)
+            mock_model.return_value = mock_llm
+
+            agent = MCPToolAgent("1", mock_tools)
+            result = await agent.ainvoke({"query": "Calculate 5+5 and 2*10"})
+
+            # Both tools ran (and overlapped -- otherwise slow_add couldn't return 10).
+            assert started["add"].is_set()
+            assert started["multiply"].is_set()
+            # Ordering matches tool_calls order even though 'add' finished last.
+            assert result["tool_results"] == [
+                {"tool": "add", "result": 10},
+                {"tool": "multiply", "result": 20},
+            ]
+
+    @pytest.mark.asyncio
+    async def test_kwargs_forwarded_to_llm(self, mock_tools):
+        """Regression test: caller-supplied kwargs must reach the underlying llm.ainvoke.
+
+        Previously ainvoke accepted **kwargs but never forwarded them, so run
+        options (e.g. `stop`) were silently dropped."""
+        with patch("connectchain.tools.mcp.agent.model") as mock_model:
+            mock_llm = AsyncMock()
+            mock_response = AIMessage(content="The answer is 42")
+            mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+            mock_llm.bind_tools = Mock(return_value=mock_llm)
+            mock_model.return_value = mock_llm
+
+            agent = MCPToolAgent("1", mock_tools)
+            await agent.ainvoke({"query": "What is 2+2?"}, None, stop=["\n"], temperature=0.1)
+
+            mock_llm.ainvoke.assert_awaited_once_with(
+                {"query": "What is 2+2?"}, None, stop=["\n"], temperature=0.1
+            )
 
     def test_invoke_runtime_error(self, mock_tools):
         """Test synchronous invoke raises RuntimeError with helpful message."""


### PR DESCRIPTION
## Fixes

Four defects in the MCP tool layer, plus a performance improvement:

- **`MCPToolLoader.load_tools([])`** treated an explicit empty list as "no filter" (load everything) instead of "no tools".
- **Same-name tool collisions across servers** silently dropped tools; now logs a warning naming the collision.
- **`MCPToolAgent.ainvoke`** violated its own `-> dict` return type when no tool was called.
- **`ainvoke` dropped `**kwargs`** instead of forwarding them to `llm.ainvoke`.
- **Independent tool calls now run concurrently** via `asyncio.gather` (order-preserving; per-tool error isolation unchanged — one failing/slow tool cannot affect siblings).

## Verification

- `tests/unit_tests/tools/test_mcp.py`: 11 passed, including a rendezvous test (`asyncio.Event`-based, no wall-clock sleeps) that only passes under true concurrency — it fails on revert to the sequential loop.
- Cross-checked: the MCP modules depend on nothing outside this diff (loader uses `config.data.get(...)` dict access; `model()` call signature unchanged).

## Sequencing

Includes the shared dependency pin (needed to build standalone); that hunk rebases away once #10 merges. Otherwise independent of the other PRs in the series.

Co-authored-by: Claude <noreply@anthropic.com>
